### PR TITLE
Support ClangFormat v17.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/17.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
-*   [ClangFormat](https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormat.html)
+*   [ClangFormat](https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Thus UniversalIndentGUI is open for nearly any new indenter and programming lang
 
 *   [Artistic Styler](http://astyle.sourceforge.net/)
 *   [BCPP](http://invisible-island.net/bcpp/)
+*   [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
 *   [Cobol Beautify](http://www.siber.com/sct/tools/cbl-beau.html)
 *   [CSSTidy](http://csstidy.sourceforge.net/)
 *   [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/)
@@ -140,7 +141,7 @@ But if you'd like to build UiGUI from source, follow these steps:
 5.  Run "make release".
 6.  Install it
         **Indenter binary packages** can be downloaded from the project at SourceForge
-        [here](http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094).
+        [here](http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094). **ClangFormat** is not part of them (yet), and you can download it separately at [the LLVM Builds page](http://llvm.org/builds/). (Rename it to `clang-format.exe` after downloading if needed.)
 
 Beneath the possibility to build UiGUI using qmake, also project files for Visual Studio 2005
         and XCode are included.

--- a/README_older_but_worth_reading.txt
+++ b/README_older_but_worth_reading.txt
@@ -17,6 +17,7 @@ One of the main features and the reason why this tool was (better is being) deve
 - Supports the following indenters:
   * Artistic Styler
   * BCPP
+  * ClangFormat
   * Cobol Beautifier
   * CSS Tidy
   * GNU Indent

--- a/buildRelease.sh
+++ b/buildRelease.sh
@@ -348,7 +348,7 @@ echo ""
 echo "Copying the indenter executable files to the target indenters dir"
 echo "-----------------------------------------------------------------"
 # This list does not include script based indenters. These are copied somewhere below.
-indenters="astyle$ext astyle.html uncrustify$ext uncrustify.txt xmlindent$ext xmlindent.txt"
+indenters="astyle$ext astyle.html clang-format$ext uncrustify$ext uncrustify.txt xmlindent$ext xmlindent.txt"
 # For win32 and Linux add some indenters that do not run or exist under MaxOSX
 if [ "$targetSystem" = "win32" ] || [ "$targetSystem" = "linux" ]; then
     indenters="$indenters bcpp$ext bcpp.txt csstidy$ext f90ppr.exe f90ppr.txt greatcode.exe greatcode.txt htb.exe htb.html indent$ext indent.html phpCB.html phpCB.exe psti_license.txt psti_manual.html psti.exe tidy$ext tidy.html vbsbeaut_keywords_indent.txt vbsbeaut_keywords.txt vbsbeaut.bat vbsbeaut.exe"

--- a/buildwin32release_gcc.bat
+++ b/buildwin32release_gcc.bat
@@ -55,7 +55,7 @@ echo.
 
 echo Copying the indenter executables and example file to the release indenters dir
 echo ------------------------------------------------------------------------------
-FOR %%A IN ( astyle.exe, astyle.html, bcpp.exe, bcpp.txt, csstidy.exe, gc.exe, gc.txt, indent.exe, libiconv-2.dll, libintl-2.dll, indent.html, JsDecoder.js, perltidy, PerlTidyLib.pm, phpStylist.php, phpStylist.txt, rbeautify.rb, ruby_formatter.rb, shellindent.awk, tidy.exe, tidy.html, uncrustify.exe, uncrustify.txt, xmlindent.exe, xmlindent.txt ) DO (
+FOR %%A IN ( astyle.exe, astyle.html, bcpp.exe, bcpp.txt, clang-format.exe csstidy.exe, gc.exe, gc.txt, indent.exe, libiconv-2.dll, libintl-2.dll, indent.html, JsDecoder.js, perltidy, PerlTidyLib.pm, phpStylist.php, phpStylist.txt, rbeautify.rb, ruby_formatter.rb, shellindent.awk, tidy.exe, tidy.html, uncrustify.exe, uncrustify.txt, xmlindent.exe, xmlindent.txt ) DO (
     if not exist .\indenters\%%A (
         echo WARNING!! File .\indenters\%%A not found!
 		set warningsoccurred=true

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -2,27 +2,27 @@
 categories="Overall Policy|Breaking and Joining|Brace Positioning|Indentation|Alignment|Horizontal Spacing|Vertical Spacing|Other Edits"
 cfgFileParameterEnding=cr
 configFilename=.clang-format
-fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.m|*.mm|*.M|*.proto|*.cs
+fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.json|*.m|*.mm|*.M|*.proto|*.cs
 indenterFileName=clang-format
-indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf, C#)
+indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=12.0.0
+version=13.0.0
 
 [Language]
 Category=0
 Description="<html>(Language) Language this format style is targeted at.</html>"
 EditorType=multiple
 Enabled=true
-Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen|Language: CSharp"
-ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen|(CSharp) C#"
+Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: Json|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen|Language: CSharp"
+ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(Json) JSON|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen|(CSharp) C#"
 ValueDefault=0
 
 [BasedOnStyle]
@@ -30,8 +30,8 @@ Category=0
 Description="<html>(BasedOnStyle) The style used for all options not specifically set in the configuration.</html>"
 EditorType=multiple
 Enabled=false
-Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft|BasedOnStyle: GNU"
-ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017|(GNU) GNU coding standards - https://www.gnu.org/prep/standards/standards.html"
+Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft|BasedOnStyle: GNU|BasedOnStyle: InheritParentConfig"
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017|(GNU) GNU coding standards - https://www.gnu.org/prep/standards/standards.html|(InheritParentConfig) Not a real style, but allows to use the .clang-format file from the parent directory (or its parent if there is none)."
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -53,6 +53,15 @@ Enabled=false
 Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak"
 ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line."
 ValueDefault=0
+
+[AlignArrayOfStructures]
+Category=4
+Description="<html>(AlignArrayOfStructures) if not <code>None</code>, when using initialization for an array of structs aligns the fields into columns.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignArrayOfStructures: Left|AlignArrayOfStructures: Right|AlignArrayOfStructures: None"
+ChoicesReadable="(Left) Align array column and left justify the columns|(Right) Align array column and right justify the columns|(None) Don't align array initializer columns."
+ValueDefault=2
 
 [AlignConsecutiveAssignments]
 Category=4
@@ -176,11 +185,11 @@ ValueDefault=4
 
 [AllowShortIfStatementsOnASingleLine]
 Category=1
-Description="<html>(AllowShortIfStatementsOnASingleLine) If <code>true</code>, <code>if (a) return;</code> can be put on a single line.</html>"
+Description="<html>(AllowShortIfStatementsOnASingleLine) Dependent on the value, <code>if (a) return;</code> can be put on a single line.</html>"
 EditorType=multiple
 Enabled=false
-Choices="AllowShortIfStatementsOnASingleLine: Never|AllowShortIfStatementsOnASingleLine: WithoutElse|AllowShortIfStatementsOnASingleLine: Always"
-ChoicesReadable="(Never) Never put short ifs on the same line.|(WithoutElse) Without else put short ifs on the same line only if the else is not a compound statement.|(Always) Always put short ifs on the same line if the else is not a compound statement or not."
+Choices="AllowShortIfStatementsOnASingleLine: Never|AllowShortIfStatementsOnASingleLine: WithoutElse|AllowShortIfStatementsOnASingleLine: OnlyFirstIf|AllowShortIfStatementsOnASingleLine: AllIfsAndElse"
+ChoicesReadable="(Never) Never put short ifs on the same line.|(WithoutElse) Put short ifs on the same line only if there is no else statement.|(OnlyFirstIf) Put short ifs, but not else ifs nor else statements, on the same line.|(AllIfsAndElse) Always put short ifs, else ifs and else statements on the same line."
 ValueDefault=0
 
 [AllowShortLambdasOnASingleLine]
@@ -478,8 +487,8 @@ Category=1
 Description="<html>(BreakInheritanceList) The inheritance list style to use.</html>"
 EditorType=multiple
 Enabled=false
-Choices="BreakInheritanceList: BeforeColon|BreakInheritanceList: BeforeComma|BreakInheritanceList: AfterColon"
-ChoicesReadable="(BeforeColon) Break inheritance list before the colon and after the commas.|(BeforeComma) Break inheritance list before the colon and commas, and align the commas with the colon.|(AfterColon) Break inheritance list after the colon and commas."
+Choices="BreakInheritanceList: BeforeColon|BreakInheritanceList: BeforeComma|BreakInheritanceList: AfterColon|BreakInheritanceList: AfterComma"
+ChoicesReadable="(BeforeColon) Break inheritance list before the colon and after the commas.|(BeforeComma) Break inheritance list before the colon and commas, and align the commas with the colon.|(AfterColon) Break inheritance list after the colon and commas.|(AfterComma) Break inheritance list only after the commas."
 ValueDefault=0
 
 [BreakStringLiterals]
@@ -580,6 +589,15 @@ TrueFalse="DisableFormat: true|DisableFormat: false"
 Value=0
 ValueDefault=0
 
+[EmptyLineAfterAccessModifier]
+Category=6
+Description="<html>(EmptyLineAfterAccessModifier) Defines when to put an empty line after access modifiers. <code>EmptyLineBeforeAccessModifier</code> configuration handles the number of empty lines between two access modifiers.</html>"
+EditorType=multiple
+Enabled=false
+Choices="EmptyLineAfterAccessModifier: Never|EmptyLineAfterAccessModifier: Leave|EmptyLineAfterAccessModifier: Always"
+ChoicesReadable="(Never) Remove all empty lines after access modifiers.|(Leave) Keep existing empty lines after access modifiers. MaxEmptyLinesToKeep is applied instead.|(Always) Always add empty line after access modifiers if there are none. MaxEmptyLinesToKeep is applied also."
+ValueDefault=0
+
 [EmptyLineBeforeAccessModifier]
 Category=6
 Description="<html>(EmptyLineBeforeAccessModifier) Defines in which cases to put empty line before access modifiers.</html>"
@@ -591,7 +609,7 @@ ValueDefault=2
 
 [FixNamespaceComments]
 Category=7
-Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a                       }</pre></html>"
+Description="<html>If <code>true</code>, clang-format adds missing namespace end comments for short namespaces and fixes invalid existing ones. Short ones are controlled by "ShortNamespaceLines".<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>bar();                                 bar();<br/>} // namespace a                       }</pre></html>"
 EditorType=boolean
 TrueFalse="FixNamespaceComments: true|FixNamespaceComments: false"
 Value=1
@@ -605,6 +623,15 @@ CallName="ForEachMacros: "
 Enabled=false
 Value="['foreach', 'Q_FOREACH', 'BOOST_FOREACH']"
 ValueDefault="['foreach', 'Q_FOREACH', 'BOOST_FOREACH']"
+
+[IfMacros]
+Category=7
+Description="<html>A vector of macros that should be interpreted as conditionals instead of as function calls.<p>These are expected to be macros of the form:</p><pre>    IF(...)<br/>      &lt;conditional-body&gt;<br/>    else IF(...)<br/>      &lt;conditional-body&gt;</pre></html>"
+EditorType=string
+CallName="IfMacros: "
+Enabled=false
+Value="['KJ_IF_MAYBE']"
+ValueDefault="['KJ_IF_MAYBE']"
 
 [IncludeBlocks]
 Category=7
@@ -632,6 +659,14 @@ CallName="IncludeIsMainSourceRegex: "
 Enabled=false
 Value="''"
 ValueDefault="''"
+
+[IndentAccessModifiers]
+Category=3
+Description="<html>Specify whether access modifiers should have their own indentation level.<p>When <code>false</code>, access modifiers are indented (or outdented) relative to the record members, respecting the <code>AccessModifierOffset</code>. Record members are indented one level below the record.</p><p>When <code>true</code>, access modifiers get their own indentation level. As a consequence, record members are always indented 2 levels below the record, regardless of the access modifier presence. Value of the <code>AccessModifierOffset</code> is ignored.</p><pre>     false:                                 true:<br/>     class C {                      vs.     class C {<br/>       class D {                                class D {<br/>         void bar();                                void bar();<br/>       protected:                                 protected:<br/>         D();                                       D();<br/>       };                                       };<br/>     public:                                  public:<br/>       C();                                     C();<br/>     };                                     };<br/>     void foo() {                           void foo() {<br/>       return 1;                              return 1;<br/>     }                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="IndentAccessModifiers: true|IndentAccessModifiers: false"
+Value=0
+ValueDefault=0
 
 [IndentCaseBlocks]
 Category=3
@@ -743,6 +778,15 @@ Description="<html>If <code>true</code>, the empty line at the start of blocks i
 EditorType=boolean
 TrueFalse="KeepEmptyLinesAtTheStartOfBlocks: true|KeepEmptyLinesAtTheStartOfBlocks: false"
 Value=0
+ValueDefault=0
+
+[LambdaBodyIndentation]
+Category=3
+Description="<html>(LambdaBodyIndentation) The indentation style of lambda bodies.</html>"
+EditorType=multiple
+Enabled=false
+Choices="LambdaBodyIndentation: Signature|LambdaBodyIndentation: OuterScope"
+ChoicesReadable="(Signature) Align lambda body relative to the lambda signature. This is the default.|(OuterScope) Align lambda body relative to the indentation level of the outer scope the lambda signature resides in."
 ValueDefault=0
 
 [MacroBlockBegin]
@@ -944,6 +988,26 @@ Choices="PointerAlignment: Left|PointerAlignment: Middle|PointerAlignment: Right
 ChoicesReadable="(Left) Align pointer to the left.|(Middle) Align pointer in the middle.|(Right) Align pointer to the right."
 ValueDefault=2
 
+[PPIndentWidth]
+Category=3
+Description="<html>The number of columns to use for indentation of preprocessor statements. When set to -1 (default) <code>IndentWidth</code> is used also for preprocessor statements.<pre>     PPIndentWidth: 1<br/><br/>     #ifdef __linux__<br/>     # define FOO<br/>     #else<br/>     # define BAR<br/>     #endif</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="PPIndentWidth: "
+MaxVal=10000000
+MinVal=-1
+Value=-1
+ValueDefault=-1
+
+[ReferenceAlignment]
+Category=4
+Description="<html>(ReferenceAlignment) Reference alignment style (overrides <code>PointerAlignment</code> for references).</html>"
+EditorType=multiple
+Enabled=false
+Choices="ReferenceAlignment: Pointer|ReferenceAlignment: Left|ReferenceAlignment: Right|ReferenceAlignment: Middle"
+ChoicesReadable="(Pointer) Align reference like PointerAlignment.|(Left) Align reference to the left.|(Right) Align reference to the right.|(Middle) Align reference in the middle."
+ValueDefault=0
+
 [ReflowComments]
 Category=1
 Description="<html>If <code>true</code>, clang-format will attempt to re-flow comments.<pre>false:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information */<br/><br/>true:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/>// information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/> * information */</pre></html>"
@@ -952,12 +1016,25 @@ TrueFalse="ReflowComments: true|ReflowComments: false"
 Value=1
 ValueDefault=1
 
+[ShortNamespaceLines]
+Category=7
+Description="<html>The maximal number of unwrapped lines that a short namespace spans. Defaults to 1.<p>This determines the maximum length of short namespaces by counting unwrapped lines (i.e. containing neither opening nor closing namespace brace) and makes <code>FixNamespaceComments</code> omit adding end comments for those.</p><pre>     ShortNamespaceLines: 1     vs.     ShortNamespaceLines: 0<br/>     namespace a {                      namespace a {<br/>       int foo;                           int foo;
+     }                                  } // namespace a<br/><br/>     ShortNamespaceLines: 1     vs.     ShortNamespaceLines: 0<br/>     namespace b {                      namespace b {<br/>       int foo;                           int foo;<br/>       int bar;                           int bar;<br/>     } // namespace b                   } // namespace b</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="ShortNamespaceLines: "
+MaxVal=10000000
+MinVal=0
+Value=1
+ValueDefault=1
+
 [SortIncludes]
 Category=7
-Description="<html>If <code>true</code>, clang-format will sort <code>#include</code>s.<pre>false:                                 true:<br/>#include &quot;b.h&quot;                 vs.     #include &quot;a.h&quot;<br/>#include &quot;a.h&quot;                         #include &quot;b.h&quot;</pre></html>"
-EditorType=boolean
-TrueFalse="SortIncludes: true|SortIncludes: false"
-Value=1
+Description="<html>(SortIncludes) Controls if and how clang-format will sort <code>#include</code>s.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SortIncludes: Never|SortIncludes: CaseSensitive|SortIncludes: CaseInsensitive"
+ChoicesReadable="(Never) Includes are never sorted.|(CaseSensitive) Includes are sorted in an ASCIIbetical or case sensitive fashion.|(CaseInsensitive) Includes are sorted in an alphabetical or case insensitive fashion."
 ValueDefault=1
 
 [SortJavaStaticImport]
@@ -1104,10 +1181,11 @@ ValueDefault=1
 
 [SpacesInAngles]
 Category=5
-Description="<html>If <code>true</code>, spaces will be inserted after &lt; and before &gt; in template argument lists.<pre>true:                                  false:<br/>static_cast&lt; int &gt;(arg);       vs.     static_cast&lt;int&gt;(arg);<br/>std::function&lt; void(int) &gt; fct;        std::function&lt;void(int)&gt; fct;</pre></html>"
-EditorType=boolean
-TrueFalse="SpacesInAngles: true|SpacesInAngles: false"
-Value=0
+Description="<html>(SpacesInAngles) The SpacesInAnglesStyle to use for template argument lists.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SpacesInAngles: Never|SpacesInAngles: Always|SpacesInAngles: Leave"
+ChoicesReadable="(Never) Remove spaces after < and before >.|(Always) Add spaces after < and before >.|(Leave) Keep a single space after < and before > if any spaces were present. Option 'Standard: Cpp03' takes precedence."
 ValueDefault=0
 
 [SpacesInCStyleCastParentheses]
@@ -1133,6 +1211,36 @@ EditorType=boolean
 TrueFalse="SpacesInContainerLiterals: true|SpacesInContainerLiterals: false"
 Value=0
 ValueDefault=0
+
+[SpacesInLineCommentPrefix]
+Category=5
+Description="<html>How many spaces are allowed at the start of a line comment. To disable the maximum set it to <code>-1</code>, apart from that the maximum takes precedence over the minimum.<pre>Minimum = 1 Maximum = -1<br/>// One space is forced<br/>//  but more spaces are possible<br/><br/>Minimum = 0<br/>Maximum = 0<br/>//Forces to start every comment directly after the slashes</pre>Note that in line comment sections the relative indent of the subsequent lines is kept, that means the following:<pre>before:                                   after:<br/>  Minimum: 1<br/>  //if (b) {                                // if (b) {<br/>  //  return true;                          //   return true;<br/>  //}                                       // }<br/><br/>  Maximum: 0<br/>  /// List:                                 ///List:<br/>  ///  - Foo                                /// - Foo<br/>  ///    - Bar                              ///   - Bar</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInLineCommentPrefix:|SpacesInLineCommentPrefix:"
+Value=1
+ValueDefault=1
+
+[Minimum]
+Category=5
+Description="<html>The minimum number of spaces at the start of the comment.</html>"
+EditorType=numeric
+Enabled=true
+CallName="    Minimum: "
+MaxVal=10000000
+MinVal=0
+Value=1
+ValueDefault=1
+
+[Maximum]
+Category=5
+Description="<html>The maximum number of spaces at the start of the comment.</html>"
+EditorType=numeric
+Enabled=true
+CallName="    Maximum: "
+MaxVal=10000000
+MinVal=-1
+Value=-1
+ValueDefault=-1
 
 [SpacesInParentheses]
 Category=5

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -1,0 +1,900 @@
+[header]
+categories="Overall Policy|Breaking and Joining|Brace Positioning|Indentation|Alignment|Horizontal Spacing|Vertical Spacing|Other Edits"
+cfgFileParameterEnding=cr
+configFilename=.clang-format
+fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.m|*.mm|*.M|*.proto
+indenterFileName=clang-format
+indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf)
+inputFileName=indentinput
+inputFileParameter="-style=file -i "
+manual=http://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+outputFileName=indentinput
+outputFileParameter=none
+parameterOrder=pio
+stringparaminquotes=false
+showHelpParameter=-help
+useCfgFileParameter=none
+version=7.0.0
+
+[Language]
+Category=0
+Description="<html>(Language) Language this format style is targeted at.</html>"
+EditorType=multiple
+Enabled=true
+Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen"
+ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen"
+ValueDefault=0
+
+[BasedOnStyle]
+Category=0
+Description="<html>(BasedOnStyle) The style used for all options not specifically set in the configuration.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit"
+ChoicesReadable="(LLVM) LLVM coding standards - http://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - http://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - http://www.webkit.org/coding/coding-style.html"
+ValueDefault=0
+
+[AccessModifierOffset]
+Category=4
+Description="<html>The extra indent or outdent of access modifiers, e.g. <code>public:</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="AccessModifierOffset: "
+MaxVal=100
+MinVal=-100
+Value=-2
+ValueDefault=-2
+
+[AlignAfterOpenBracket]
+Category=4
+Description="<html>(AlignAfterOpenBracket) Horizontally aligns arguments after an open bracket.<p>This applies to round brackets (parentheses), angle brackets and square brackets.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak"
+ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line."
+ValueDefault=0
+
+[AlignConsecutiveAssignments]
+Category=4
+Description="<html>Aligns consecutive assignments.<p>This will align the assignment operators of consecutive lines. This will result in formattings like<pre>int aaaa = 12;<br/>int b    = 23;<br/>int ccc  = 23;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveAssignments: true|AlignConsecutiveAssignments: false"
+Value=0
+ValueDefault=0
+
+[AlignConsecutiveDeclarations]
+Category=4
+Description="<html>Aligns consecutive declarations.<p>This will align the declaration names of consecutive lines. This will result in formattings like<pre>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc = 23;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveDeclarations: true|AlignConsecutiveDeclarations: false"
+Value=0
+ValueDefault=0
+
+[AlignEscapedNewlines]
+Category=4
+Description="<html>(AlignEscapedNewlines) Options for aligning backslashes in escaped newlines.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignEscapedNewlines: DontAlign|AlignEscapedNewlines: Left|AlignEscapedNewlines: Right"
+ChoicesReadable="(DontAlign) Don’t align escaped newlines.|(Left) Align escaped newlines as far left as possible.|(Right) Align escaped newlines in the right-most column."
+ValueDefault=2
+
+[AlignOperands]
+Category=4
+Description="<html>Horizontally align operands of binary and ternary expressions.<p>Specifically, this aligns operands of a single expression that needs to be split over multiple lines, e.g.:<pre>int aaa = bbbbbbbbbbbbbbb +<br/>          ccccccccccccccc;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignOperands: true|AlignOperands: false"
+Value=1
+ValueDefault=1
+
+[AlignTrailingComments]
+Category=4
+Description="<html>Aligns trailing comments.<pre>true:                                   false:<br/>int a;     // My comment a      vs.     int a; // My comment a<br/>int b = 2; // comment  b                int b = 2; // comment about b</pre></html>"
+EditorType=boolean
+TrueFalse="AlignTrailingComments: true|AlignTrailingComments: false"
+Value=1
+ValueDefault=1
+
+[AllowAllParametersOfDeclarationOnNextLine]
+Category=1
+Description="<html>If the function declaration doesn’t fit on a line, allow putting all parameters of a function declaration onto the next line even if <code>BinPackParameters</code> is <code>false</code>.<pre>true:<br/>void myFunction(<br/>    int a, int b, int c, int d, int e);<br/><br/>false:<br/>void myFunction(int a,<br/>                int b,<br/>                int c,<br/>                int d,<br/>                int e);</pre></html>"
+EditorType=boolean
+TrueFalse="AllowAllParametersOfDeclarationOnNextLine: true|AllowAllParametersOfDeclarationOnNextLine: false"
+Value=1
+ValueDefault=1
+
+[AllowShortBlocksOnASingleLine]
+Category=1
+Description="<html>Allows contracting simple braced statements to a single line.<p>E.g., this allows <code>if (a) { return; }</code> to be put on a single line (if <code>AllowShortIfStatementsOnASingleLine</code> is also enabled).</html>"
+EditorType=boolean
+TrueFalse="AllowShortBlocksOnASingleLine: true|AllowShortBlocksOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortCaseLabelsOnASingleLine]
+Category=1
+Description="<html>Contracts short case labels to a single line.<pre>true:                                   false:<br/>switch (a) {                    vs.     switch (a) {<br/>case 1: x = 1; break;                   case 1:<br/>case 2: return;                           x = 1;<br/>}                                         break;<br/>                                        case 2:<br/>                                          return;<br/>                                        }</pre></html>"
+EditorType=boolean
+TrueFalse="AllowShortCaseLabelsOnASingleLine: true|AllowShortCaseLabelsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortFunctionsOnASingleLine]
+Category=1
+Description="<html>(AllowShortFunctionsOnASingleLine) <code>int f() { return 0; }</code> can be put on a single line.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AllowShortFunctionsOnASingleLine: None|AllowShortFunctionsOnASingleLine: InlineOnly|AllowShortFunctionsOnASingleLine: Empty|AllowShortFunctionsOnASingleLine: Inline|AllowShortFunctionsOnASingleLine: All"
+ChoicesReadable="(None) Never merge functions into a single line.|(InlineOnly) Only merge functions defined inside a class.|(Empty) Only merge empty functions.|(Inline) Only merge functions defined inside a class. Implies “empty”.|(All) Merge all functions fitting on a single line."
+ValueDefault=4
+
+[AllowShortIfStatementsOnASingleLine]
+Category=1
+Description="<html><code>if (a) return;</code> can be put on a single line.<p>Note: If the statement body is a block then <code>AllowShortBlocksOnASingleLine</code> is also needed.</html>"
+EditorType=boolean
+TrueFalse="AllowShortIfStatementsOnASingleLine: true|AllowShortIfStatementsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AllowShortLoopsOnASingleLine]
+Category=1
+Description="<html><code>while (true) continue;</code> can be put on a single line.<p>Note: To put <code>do { true; } while(0);</code> on a single line, <code>AllowShortBlocksOnASingleLine</code> is also needed.</html>"
+EditorType=boolean
+TrueFalse="AllowShortLoopsOnASingleLine: true|AllowShortLoopsOnASingleLine: false"
+Value=0
+ValueDefault=0
+
+[AlwaysBreakAfterReturnType]
+Category=1
+Description="<html>(AlwaysBreakAfterReturnType) The function return type breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlwaysBreakAfterReturnType: None|AlwaysBreakAfterReturnType: All|AlwaysBreakAfterReturnType: TopLevel|AlwaysBreakAfterReturnType: AllDefinitions|AlwaysBreakAfterReturnType: TopLevelDefinitions"
+ChoicesReadable="(None) Break after return type automatically according to PenaltyReturnTypeOnItsOwnLine.|(All) Always break after the return type.|(TopLevel) Always break after the return types of top-level functions.|(AllDefinitions) Always break after the return type of function definitions.|(TopLevelDefinitions) Always break after the return type of top-level definitions."
+ValueDefault=0
+
+[AlwaysBreakBeforeMultilineStrings]
+Category=1
+Description="<html>Always break before multiline string literals.<p>This flag is meant to make cases where there are multiple multiline strings in a file look more consistent. Thus, it will only take effect if wrapping the string at that point leads to it being indented <code>ContinuationIndentWidth</code> spaces from the start of the line.</p><pre>true:                                  false:<br/>aaaa =                         vs.     aaaa = &quot;bbbb&quot;<br/>    &quot;bbbb&quot;                                    &quot;cccc&quot;;<br/>    &quot;cccc&quot;;</pre></html>"
+EditorType=boolean
+TrueFalse="AlwaysBreakBeforeMultilineStrings: true|AlwaysBreakBeforeMultilineStrings: false"
+Value=0
+ValueDefault=0
+
+[AlwaysBreakTemplateDeclarations]
+Category=1
+Description="<html>(AlwaysBreakTemplateDeclarations) The template declaration breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlwaysBreakTemplateDeclarations: No|AlwaysBreakTemplateDeclarations: MultiLine|AlwaysBreakTemplateDeclarations: Yes"
+ChoicesReadable="(No) Do not force break before declaration. PenaltyBreakTemplateDeclaration is taken into account.|(MultiLine) Force break after template declaration only when the following declaration spans multiple lines.|(Yes) Always break after template declaration."
+ValueDefault=0
+
+[BinPackArguments]
+Category=1
+Description="<html>If <code>false</code>, a function call’s arguments will either be all on the same line or will have one line each.<pre>true:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}<br/><br/>false:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="BinPackArguments: true|BinPackArguments: false"
+Value=1
+ValueDefault=1
+
+[BinPackParameters]
+Category=1
+Description="<html>If <code>false</code>, a function declaration’s or function definition’s parameters will either all be on the same line or will have one line each.<pre>true:<br/>void f(int aaaaaaaaaaaaaaaaaaaa, int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}<br/><br/>false:<br/>void f(int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaa,<br/>       int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}</pre></html>"
+EditorType=boolean
+TrueFalse="BinPackParameters: true|BinPackParameters: false"
+Value=1
+ValueDefault=1
+
+[BraceWrapping]
+Category=2
+Description="<html>Control of individual brace wrapping cases.<p>If <code>BreakBeforeBraces</code> is set to <code>Custom</code>, use the following options to specify how each individual brace case should be handled. Otherwise, this is ignored.</html>"
+EditorType=boolean
+TrueFalse="BraceWrapping:|BraceWrapping:"
+Value=1
+ValueDefault=1
+
+[ - AfterClass]
+Category=2
+Description="<html>Wrap <code>class</code> definitions.<pre>true:<br/>class foo {};<br/><br/>false:<br/>class foo<br/>{};</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterClass: true|    AfterClass: false"
+Value=0
+ValueDefault=0
+
+[ - AfterControlStatement]
+Category=2
+Description="<html>Wrap control statements (<code>if</code>/<code>for</code>/<code>while</code>/<code>switch</code>/..).<pre>true:<br/>if (foo())<br/>{<br/>} else<br/>{}<br/>for (int i = 0; i &lt; 10; ++i)<br/>{}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}<br/>for (int i = 0; i &lt; 10; ++i) {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterControlStatement: true|    AfterControlStatement: false"
+Value=0
+ValueDefault=0
+
+[ - AfterEnum]
+Category=2
+Description="<html>Wrap <code>enum</code> definitions.<pre>true:<br/>enum X : int<br/>{<br/>  B<br/>};<br/><br/>false:<br/>enum X : int { B };</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterEnum: true|    AfterEnum: false"
+Value=0
+ValueDefault=0
+
+[ - AfterFunction]
+Category=2
+Description="<html>Wrap function definitions.<pre>true:<br/>void foo()<br/>{<br/>  bar();<br/>  bar2();<br/>}<br/><br/>false:<br/>void foo() {<br/>  bar();<br/>  bar2();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterFunction: true|    AfterFunction: false"
+Value=0
+ValueDefault=0
+
+[ - AfterNamespace]
+Category=2
+Description="<html>Wrap <code>namespace</code> definitions.<pre>true:<br/>namespace<br/>{<br/>int foo();<br/>int bar();<br/>}<br/><br/>false:<br/>namespace {<br/>int foo();<br/>int bar();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterNamespace: true|    AfterNamespace: false"
+Value=0
+ValueDefault=0
+
+[ - AfterObjCDeclaration]
+Category=2
+Description="<html>Wrap ObjC definitions (interfaces, implementations…). <code>@autoreleasepool</code> and <code>@synchronized</code> blocks are wrapped according to <code>AfterControlStatement</code> flag.</html>"
+EditorType=boolean
+TrueFalse="    AfterObjCDeclaration: true|    AfterObjCDeclaration: false"
+Value=0
+ValueDefault=0
+
+[ - AfterStruct]
+Category=2
+Description="<html>Wrap <code>struct</code> definitions.<pre>true:<br/>struct foo<br/>{<br/>  int x;<br/>};<br/><br/>false:<br/>struct foo {<br/>  int x;<br/>};</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterStruct: true|    AfterStruct: false"
+Value=0
+ValueDefault=0
+
+[ - AfterUnion]
+Category=2
+Description="<html>Wrap <code>union</code> definitions.<pre>true:<br/>union foo<br/>{<br/>  int x;<br/>}<br/><br/>false:<br/>union foo {<br/>  int x;<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterUnion: true|    AfterUnion: false"
+Value=0
+ValueDefault=0
+
+[ - AfterExternBlock]
+Category=2
+Description="<html>Wrap <code>extern</code> blocks.<pre>true:<br/>extern &quot;C&quot;<br/>{<br/>  int foo();<br/>}<br/><br/>false:<br/>extern &quot;C&quot; {<br/>int foo();<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterExternBlock: true|    AfterExternBlock: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeCatch]
+Category=2
+Description="<html>Wrap before <code>catch</code>.<pre>true:<br/>try {<br/>  foo();<br/>}<br/>catch () {<br/>}<br/><br/>false:<br/>try {<br/>  foo();<br/>} catch () {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeCatch: true|    BeforeCatch: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeElse]
+Category=2
+Description="<html>Wrap before <code>else</code>.<pre>true:<br/>if (foo()) {<br/>}<br/>else {<br/>}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeElse: true|    BeforeElse: false"
+Value=0
+ValueDefault=0
+
+[ - IndentBraces]
+Category=2
+Description="<html>Indent the wrapped braces themselves.</html>"
+EditorType=boolean
+TrueFalse="    IndentBraces: true|    IndentBraces: false"
+Value=0
+ValueDefault=0
+
+[ - SplitEmptyFunction]
+Category=2
+Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>int f()   vs.   inf f()<br/>{}              {<br/>                }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyFunction: true|    SplitEmptyFunction: false"
+Value=1
+ValueDefault=1
+
+[ - SplitEmptyRecord]
+Category=2
+Description="<html>If <code>false</code>, empty record (e.g. <code>class</code>, <code>struct</code> or <code>union</code>) body can be put on a single line. This option is used only if the opening brace of the record has already been wrapped, i.e. the <code>AfterClass</code> (for classes) brace wrapping mode is set.<pre>class Foo   vs.  class Foo<br/>{}               {<br/>                 }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyRecord: true|    SplitEmptyRecord: false"
+Value=1
+ValueDefault=1
+
+[ - SplitEmptyNamespace]
+Category=2
+Description="<html>If <code>false</code>, empty namespace body can be put on a single line. This option is used only if the opening brace of the namespace has already been wrapped, i.e. the <code>AfterNamespace</code> brace wrapping mode is set.<pre>namespace Foo   vs.  namespace Foo<br/>{}                   {<br/>                     }</pre></html>"
+EditorType=boolean
+TrueFalse="    SplitEmptyNamespace: true|    SplitEmptyNamespace: false"
+Value=1
+ValueDefault=1
+
+[BreakAfterJavaFieldAnnotations]
+Category=1
+Description="<html>Break after each annotation on a field in Java files.<pre>true:                                  false:<br/>@Partial                       vs.     @Partial @Mock DataLoad loader;<br/>@Mock<br/>DataLoad loader;</pre></html>"
+EditorType=boolean
+TrueFalse="BreakAfterJavaFieldAnnotations: true|BreakAfterJavaFieldAnnotations: false"
+Value=0
+ValueDefault=0
+
+[BreakBeforeBinaryOperators]
+Category=1
+Description="<html>(BreakBeforeBinaryOperators) The way to wrap binary operators.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeBinaryOperators: None|BreakBeforeBinaryOperators: NonAssignment|BreakBeforeBinaryOperators: All"
+ChoicesReadable="(None) Break after operators.|(NonAssignment) Break before operators that aren’t assignments.|(All) Break before operators."
+ValueDefault=0
+
+[BreakBeforeBraces]
+Category=2
+Description="<html>(BreakBeforeBraces) The brace breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: Mozilla|BreakBeforeBraces: Stroustrup|BreakBeforeBraces: Allman|BreakBeforeBraces: GNU|BreakBeforeBraces: WebKit|BreakBeforeBraces: Custom"
+ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
+ValueDefault=0
+
+[BreakBeforeTernaryOperators]
+Category=1
+Description="<html>Ternary operators will be placed after line breaks.<pre>true:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription<br/>    ? firstValue<br/>    : SecondValueVeryVeryVeryVeryLong;<br/><br/>false:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?<br/>    firstValue :<br/>    SecondValueVeryVeryVeryVeryLong;</pre></html>"
+EditorType=boolean
+TrueFalse="BreakBeforeTernaryOperators: true|BreakBeforeTernaryOperators: false"
+Value=0
+ValueDefault=0
+
+[BreakConstructorInitializers]
+Category=1
+Description="<html>(BreakConstructorInitializers) The constructor initializers style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakConstructorInitializers: BeforeColon|BreakConstructorInitializers: BeforeComma|BreakConstructorInitializers: AfterColon"
+ChoicesReadable="(BeforeColon) Break constructor initializers before the colon and after the commas.|(BeforeComma) Break constructor initializers before the colon and commas, and align the commas with the colon.|(AfterColon) Break constructor initializers after the colon and commas."
+ValueDefault=0
+
+[BreakInheritanceList]
+Category=1
+Description="<html>(BreakInheritanceList) The inheritance list style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakInheritanceList: BeforeColon|BreakInheritanceList: BeforeComma|BreakInheritanceList: AfterColon"
+ChoicesReadable="(BeforeColon) Break inheritance list before the colon and after the commas.|(BeforeComma) Break inheritance list before the colon and commas, and align the commas with the colon.|(AfterColon) Break inheritance list after the colon and commas."
+ValueDefault=0
+
+[BreakStringLiterals]
+Category=1
+Description="<html>Allow breaking string literals when formatting.</html>"
+EditorType=boolean
+TrueFalse="BreakStringLiterals: true|BreakStringLiterals: false"
+Value=1
+ValueDefault=1
+
+[ColumnLimit]
+Category=1
+Description="<html>The column limit.<p>A column limit of <code>0</code> means that there is no column limit. In this case, clang-format will respect the input’s line breaking decisions within statements unless they contradict other rules.</html>"
+EditorType=numeric
+Enabled=false
+CallName="ColumnLimit: "
+MaxVal=2000
+MinVal=0
+Value=80
+ValueDefault=80
+
+[CommentPragmas]
+Category=1
+Description="<html>A regular expression that describes comments with special meaning, which should not be split into lines or otherwise changed.<pre>// CommentPragmas: '^ FOOBAR pragma:'<br/>// Will leave the following line unaffected<br/>#include &lt;vector&gt; // FOOBAR pragma: keep</pre></html>"
+EditorType=string
+CallName="CommentPragmas: "
+Enabled=false
+Value="'^ IWYU pragma:'"
+ValueDefault="'^ IWYU pragma:'"
+
+[CompactNamespaces]
+Category=1
+Description="<html>If <code>true</code>, consecutive namespace declarations will be on the same line. If <code>false</code>, each namespace is declared on a new line.<pre>true:<br/>namespace Foo { namespace Bar {<br/>}}<br/><br/>false:<br/>namespace Foo {<br/>namespace Bar {<br/>}<br/>}</pre><p>If it does not fit on a single line, the overflowing namespaces get wrapped:</p><pre>namespace Foo { namespace Bar {<br/>namespace Extra {<br/>}}}</html>"
+EditorType=boolean
+TrueFalse="CompactNamespaces: true|CompactNamespaces: false"
+Value=0
+ValueDefault=0
+
+[ConstructorInitializerAllOnOneLineOrOnePerLine]
+Category=1
+Description="<html>If the constructor initializers don’t fit on a line, put each initializer on its own line.<pre>true:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}<br/><br/>false:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa),<br/>      aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="ConstructorInitializerAllOnOneLineOrOnePerLine: true|ConstructorInitializerAllOnOneLineOrOnePerLine: false"
+Value=0
+ValueDefault=0
+
+[ConstructorInitializerIndentWidth]
+Category=3
+Description="<html>The number of characters to use for indentation of constructor initializer lists.</html>"
+EditorType=numeric
+Enabled=false
+CallName="ConstructorInitializerIndentWidth: "
+MaxVal=2000
+MinVal=0
+Value=4
+ValueDefault=4
+
+[ContinuationIndentWidth]
+Category=3
+Description="<html>Indent width for line continuations.<pre>ContinuationIndentWidth: 2<br/><br/>int i =         //  VeryVeryVeryVeryVeryLongComment<br/>  longFunction( // Again a long comment<br/>    arg);</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="ConstructorInitializerIndentWidth: "
+MaxVal=2000
+MinVal=0
+Value=4
+ValueDefault=4
+
+[Cpp11BracedListStyle]
+Category=5
+Description="<html>If <code>true</code>, format braced lists as best suited for C++11 braced lists.<p>Important differences:<ul><li>No spaces inside the braced list.</li><li>No line break before the closing brace.</li><li>Indentation with the continuation indent, not with the block indent.</li></ul><p>Fundamentally, C++11 braced lists are formatted exactly like function calls would be formatted in their place. If the braced list follows a name (e.g. a type or variable name), clang-format formats as if the <code>{}</code> were the parentheses of a function call with that name. If there is no name, a zero-length name is assumed.<pre>true:                                  false:<br/>vector&lt;int&gt; x{1, 2, 3, 4};     vs.     vector&lt;int&gt; x{ 1, 2, 3, 4 };<br/>vector&lt;T&gt; x{{}, {}, {}, {}};           vector&lt;T&gt; x{ {}, {}, {}, {} };<br/>f(MyMap[{composite, key}]);            f(MyMap[{ composite, key }]);<br/>new int[3]{1, 2, 3};                   new int[3]{ 1, 2, 3 };</pre></html>"
+EditorType=boolean
+TrueFalse="Cpp11BracedListStyle: true|Cpp11BracedListStyle: false"
+Value=1
+ValueDefault=1
+
+[DerivePointerAlignment]
+Category=5
+Description="<html>If <code>true</code>, analyze the formatted file for the most common alignment of <code>&</code> and <code>*</code>. Pointer and reference alignment styles are going to be updated according to the preferences found in the file. <code>PointerAlignment</code> is then used only as fallback.</html>"
+EditorType=boolean
+TrueFalse="DerivePointerAlignment: true|DerivePointerAlignment: false"
+Value=0
+ValueDefault=0
+
+[DisableFormat]
+Category=0
+Description="<html>Disables formatting completely.</html>"
+EditorType=boolean
+TrueFalse="DisableFormat: true|DisableFormat: false"
+Value=0
+ValueDefault=0
+
+[FixNamespaceComments]
+Category=7
+Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a;                      }</pre></html>"
+EditorType=boolean
+TrueFalse="FixNamespaceComments: true|FixNamespaceComments: false"
+Value=1
+ValueDefault=1
+
+[ForEachMacros]
+Category=7
+Description="<html>A vector of macros that should be interpreted as foreach loops instead of as function calls.<p>These are expected to be macros of the form:<pre>FOREACH(<variable-declaration>, ...)<br/>  <loop-body></pre><p>In the <code>.clang-format</code> configuration file, this can be configured like:<pre>ForEachMacros: ['RANGES_FOR', 'FOREACH']</pre><p>For example: <code>BOOST_FOREACH</code>.</html>"
+EditorType=string
+CallName="ForEachMacros: "
+Enabled=false
+Value="['foreach', 'Q_FOREACH', 'BOOST_FOREACH']"
+ValueDefault="['foreach', 'Q_FOREACH', 'BOOST_FOREACH']"
+
+[IncludeBlocks]
+Category=7
+Description="<html>(IncludeBlocks) Dependent on the value, multiple <code>#include</code> blocks can be sorted as one and divided based on category.</html>"
+EditorType=multiple
+Enabled=false
+Choices="IncludeBlocks: Preserve|IncludeBlocks: Merge|IncludeBlocks: Regroup"
+ChoicesReadable="(Preserve) Sort each #include block separately.|(Merge) Merge multiple #include blocks together and sort as one.|(Regroup) Merge multiple #include blocks together and sort as one. Then split into groups based on category priority. See IncludeCategories."
+ValueDefault=0
+
+[IncludeIsMainRegex]
+Category=7
+Description="<html>Specify a regular expression of suffixes that are allowed in the file-to-main-include mapping.<p>When guessing whether a <code>#include</code> is the “main” include, use this regex of allowed suffixes to the header stem. A partial match is done, so that: - “” means “arbitrary suffix” - “<code>$</code>” means “no suffix”.<p>For example, if configured to “<code>(_test)?$</code>”, then a header <code>a.h</code> would be seen as the “main” include in both <code>a.cc</code> and <code>a_test.cc</code>.</html>"
+EditorType=string
+CallName="IncludeIsMainRegex: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[IndentCaseLabels]
+Category=3
+Description="<html>Indent <code>case</code> labels one level from the <code>switch</code> statement.<p>When <code>false</code>, use the same indentation level as for the <code>switch</code> statement. Switch statement body is always indented one level more than <code>case</code> labels.<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1:                                  case 1:<br/>  bar();                                   bar();<br/>  break;                                   break;<br/>default:                                 default:<br/>  plop();                                  plop();<br/>}                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="IndentCaseLabels: true|IndentCaseLabels: false"
+Value=0
+ValueDefault=0
+
+[IndentPPDirectives]
+Category=3
+Description="<html>The preprocessor directive indenting style to use.</html>"
+EditorType=boolean
+TrueFalse="IndentPPDirectives: AfterHash|IndentPPDirectives: None"
+Value=0
+ValueDefault=0
+
+[IndentWidth]
+Category=3
+Description="<html>The number of columns to use for indentation.<pre>IndentWidth: 3<br/><br/>void f() {<br/>   someFunction();<br/>   if (true, false) {<br/>      f();<br/>   }<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="IndentWidth: "
+MaxVal=1000
+MinVal=0
+Value=2
+ValueDefault=2
+
+[IndentWrappedFunctionNames]
+Category=3
+Description="<html>Indent if a function definition or declaration is wrapped after the type.<pre>true:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>    LoooooooooooooooooooooooooooooooongFunctionDeclaration();<br/><br/>false:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>LoooooooooooooooooooooooooooooooongFunctionDeclaration();</pre></html>"
+EditorType=boolean
+TrueFalse="IndentWrappedFunctionNames: true|IndentWrappedFunctionNames: false"
+Value=0
+ValueDefault=0
+
+[JavaScriptQuotes]
+Category=7
+Description="<html>(JavaScriptQuotes) The quote style to use for JavaScript strings.</html>"
+EditorType=multiple
+Enabled=false
+Choices="JavaScriptQuotes: Leave|JavaScriptQuotes: Single|JavaScriptQuotes: Double"
+ChoicesReadable="(Leave) Leave string quotes as they are.|(Single) Always use single quotes.|(Double) Always use double quotes."
+ValueDefault=0
+
+[JavaScriptWrapImports]
+Category=1
+Description="<html>Whether to wrap JavaScript <code>import</code>/<code>export</code> statements.<pre>true:<br/>import {<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>} from 'some/module.js'<br/><br/>false:<br/>import {VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying,} from &quot;some/module.js&quot;</pre></html>"
+EditorType=boolean
+TrueFalse="JavaScriptWrapImports: true|JavaScriptWrapImports: false"
+Value=0
+ValueDefault=0
+
+[KeepEmptyLinesAtTheStartOfBlocks]
+Category=6
+Description="<html>If <code>true</code>, the empty line at the start of blocks is kept.<pre>true:                                  false:<br/>if (foo) {                     vs.     if (foo) {<br/>                                         bar();<br/>  bar();                               }<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="KeepEmptyLinesAtTheStartOfBlocks: true|KeepEmptyLinesAtTheStartOfBlocks: false"
+Value=0
+ValueDefault=0
+
+[MacroBlockBegin]
+Category=3
+Description="<html>A regular expression matching macros that start a block.</html>"
+EditorType=string
+CallName="MacroBlockBegin: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[MacroBlockEnd]
+Category=3
+Description="<html>A regular expression matching macros that end a block.</html>"
+EditorType=string
+CallName="MacroBlockEnd: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
+[MaxEmptyLinesToKeep]
+Category=6
+Description="<html>The maximum number of consecutive empty lines to keep.</pre>MaxEmptyLinesToKeep: 1         vs.     MaxEmptyLinesToKeep: 0<br/>int f() {                              int f() {<br/>  int = 1;                                 int i = 1;<br/>                                           i = foo();<br/>  i = foo();                               return i;<br/>                                       }<br/>  return i;<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="MaxEmptyLinesToKeep: "
+MaxVal=1000
+MinVal=0
+Value=1
+ValueDefault=1
+
+[NamespaceIndentation]
+Category=3
+Description="<html>(NamespaceIndentation) The indentation used for namespaces.</html>"
+EditorType=multiple
+Enabled=false
+Choices="NamespaceIndentation: None|NamespaceIndentation: Inner|NamespaceIndentation: All"
+ChoicesReadable="(None) Don’t indent in namespaces.|(Inner) Indent only in inner namespaces (nested in other namespaces).|(All) Indent in all namespaces."
+ValueDefault=0
+
+[ObjCBinPackProtocolList]
+Category=1
+Description="<html>(ObjCBinPackProtocolList) Controls bin-packing Objective-C protocol conformance list items into as few lines as possible when they go over <code>ColumnLimit</code>.<p>If <code>Auto</code> (the default), delegates to the value in <code>BinPackParameters</code>. If that is <code>true</code>, bin-packs Objective-C protocol conformance list items into as few lines as possible whenever they go over <code>ColumnLimit</code>.<p>If <code>Always</code>, always bin-packs Objective-C protocol conformance list items into as few lines as possible whenever they go over <code>ColumnLimit</code>.<p>If <code>Never</code>, lays out Objective-C protocol conformance list items onto individual lines whenever they go over <code>ColumnLimit</code>.<pre>Always (or Auto, if BinPackParameters=true):<br/>@interface ccccccccccccc () &lt;<br/>    ccccccccccccc, ccccccccccccc,<br/>    ccccccccccccc, ccccccccccccc> {<br/>}<br/><br/>Never (or Auto, if BinPackParameters=false):<br/>@interface ddddddddddddd () &lt;<br/>    ddddddddddddd,<br/>    ddddddddddddd,<br/>    ddddddddddddd,<br/>    ddddddddddddd> {<br/>}</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="ObjCBinPackProtocolList: Auto|ObjCBinPackProtocolList: Always|ObjCBinPackProtocolList: Never"
+ChoicesReadable="(Auto) Automatically determine parameter bin-packing behavior.|(Always) Always bin-pack parameters.|(Never) Never bin-pack parameters."
+ValueDefault=0
+
+[ObjCBlockIndentWidth]
+Category=3
+Description="<html>The number of characters to use for indentation of ObjC blocks.<pre>ObjCBlockIndentWidth: 4<br/><br/>[operation setCompletionBlock:^{<br/>    [self onOperationDone];<br/>}];</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="ObjCBlockIndentWidth: "
+MaxVal=1000
+MinVal=0
+Value=2
+ValueDefault=2
+
+[ObjCSpaceAfterProperty]
+Category=5
+Description="<html>Add a space after <code>@property</code> in Objective-C, i.e. use <code>@property (readonly)</code> instead of <code>@property(readonly)</code>.</html>"
+EditorType=boolean
+TrueFalse="ObjCSpaceAfterProperty: true|ObjCSpaceAfterProperty: false"
+Value=0
+ValueDefault=0
+
+[ObjCSpaceBeforeProtocolList]
+Category=5
+Description="<html>Add a space in front of an Objective-C protocol list, i.e. use <code>Foo &lt;Protocol&gt;</code> instead of <code>Foo&lt;Protocol&gt;</code>.</html>"
+EditorType=boolean
+TrueFalse="ObjCSpaceBeforeProtocolList: true|ObjCSpaceBeforeProtocolList: false"
+Value=0
+ValueDefault=0
+
+[PenaltyBreakAssignment]
+Category=1
+Description="<html>The penalty for breaking around an assignment operator.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakAssignment: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakBeforeFirstCallParameter]
+Category=1
+Description="<html>The penalty for breaking a function call after <code>call(</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakBeforeFirstCallParameter: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakComment]
+Category=1
+Description="<html>The penalty for each line break introduced inside a comment.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakComment: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakFirstLessLess]
+Category=1
+Description="<html>The penalty for breaking before the first <code>&lt;&lt;</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakFirstLessLess: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakString]
+Category=1
+Description="<html>The penalty for each line break introduced inside a string literal.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakString: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakTemplateDeclaration]
+Category=1
+Description="<html>The penalty for breaking after template declaration.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakTemplateDeclaration: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyExcessCharacter]
+Category=1
+Description="<html>The penalty for each character outside of the column limit.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyExcessCharacter: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyReturnTypeOnItsOwnLine]
+Category=1
+Description="<html>Penalty for putting the return type of a function onto its own line.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyReturnTypeOnItsOwnLine: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PointerAlignment]
+Category=5
+Description="<html>(PointerAlignment) Pointer and reference alignment style.</html>"
+EditorType=multiple
+Enabled=false
+Choices="PointerAlignment: Left|PointerAlignment: Middle|PointerAlignment: Right"
+ChoicesReadable="(Left) Align pointer to the left.|(Middle) Align pointer in the middle.|(Right) Align pointer to the right."
+ValueDefault=2
+
+[ReflowComments]
+Category=1
+Description="<html>If <code>true</code>, clang-format will attempt to re-flow comments.<pre>false:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information */<br/><br/>true:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/>// information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/> * information */</pre></html>"
+EditorType=boolean
+TrueFalse="ReflowComments: true|ReflowComments: false"
+Value=1
+ValueDefault=1
+
+[SortIncludes]
+Category=7
+Description="<html>If <code>true</code>, clang-format will sort <code>#include</code>s.<pre>false:                                 true:<br/>#include &quot;b.h&quot;                 vs.     #include &quot;a.h&quot;<br/>#include &quot;a.h&quot;                         #include &quot;b.h&quot;</pre></html>"
+EditorType=boolean
+TrueFalse="SortIncludes: true|SortIncludes: false"
+Value=1
+ValueDefault=1
+
+[SortUsingDeclarations]
+Category=7
+Descriptions="<html>If <code>true</code>, clang-format will sort <code>using</code> declarations.<p>The order of <code>using</code> declarations is defined as follows: Split the strings by “::” and discard any initial empty strings. The last element of each list is a non-namespace name; all others are namespace names. Sort the lists of names lexicographically, where the sort order of individual names is that all non-namespace names come before all namespace names, and within those groups, names are in case-insensitive lexicographic order.<pre>false:                                 true:<br/>using std::cout;               vs.     using std::cin;<br/>using std::cin;                        using std::cout;</pre></html>"
+EditorType=boolean
+TrueFalse="SortUsingDeclarations: true|SortUsingDeclarations: false"
+Value=1
+ValueDefault=1
+
+[SpaceAfterCStyleCast]
+Category=5
+Description="<html>If <code>true</code>, a space is inserted after C style casts.<pre>true:                                  false:<br/>(int) i;                       vs.     (int)i;</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceAfterCStyleCast: true|SpaceAfterCStyleCast: false"
+Value=0
+ValueDefault=0
+
+[SpaceAfterTemplateKeyword]
+Category=5
+Description="<html>If <code>true</code>, a space will be inserted after the ‘<code>template</code>’ keyword.<pre>true:                                  false:<br/>template &lt;int&gt; void foo();     vs.     template&lt;int&gt; void foo();</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceAfterTemplateKeyword: true|SpaceAfterTemplateKeyword: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeAssignmentOperators]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before assignment operators.<pre>true:                                  false:<br/>int a = 5;                     vs.     int a= 5;<br/>a += 42                                a+= 42;</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeAssignmentOperators: true|SpaceBeforeAssignmentOperators: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeCpp11BracedList]
+Category=5
+Description="<html>If <code>true</code>, a space will be inserted before a C++11 braced list used to initialize an object (after the preceding identifier or type).<pre>true:                                  false:<br/>Foo foo { bar };               vs.     Foo foo{ bar };<br/>Foo {};                                Foo{};<br/>vector<int> { 1, 2, 3 };               vector<int>{ 1, 2, 3 };<br/>new int[3] { 1, 2, 3 };                new int[3]{ 1, 2, 3 };</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeCpp11BracedList: true|SpaceBeforeCpp11BracedList: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeCtorInitializerColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before constructor initializer colon.<pre>true:                                  false:<br/>Foo::Foo() : a(a) {}                   Foo::Foo(): a(a) {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeCtorInitializerColon: true|SpaceBeforeCtorInitializerColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeInheritanceColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before inheritance colon.<pre>true:                                  false:<br/>class Foo : Bar {}             vs.     class Foo: Bar {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeInheritanceColon: true|SpaceBeforeInheritanceColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceBeforeParens]
+Category=5
+Description="<html>(SpaceBeforeParens) Defines in which cases to put a space before opening parentheses.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: Always"
+ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
+ValueDefault=1
+
+[SpaceBeforeRangeBasedForLoopColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before range-based <code>for</code> loop colon.<pre>true:                                  false:<br/>for (auto v : values) {}       vs.     for(auto v: values) {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeRangeBasedForLoopColon: true|SpaceBeforeRangeBasedForLoopColon: false"
+Value=1
+ValueDefault=1
+
+[SpaceInEmptyParentheses]
+Category=5
+Description="<html>If <code>true</code>, spaces may be inserted into <code>()</code>.<pre>true:                                false:<br/>void f( ) {                    vs.   void f() {<br/>  int x[] = {foo( ), bar( )};          int x[] = {foo(), bar()};<br/>  if (true) {                          if (true) {<br/>    f( );                                f();<br/>  }                                    }<br/>}                                    }</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceInEmptyParentheses: true|SpaceInEmptyParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpaceBeforeTrailingComments]
+Category=5
+Description="<html>The number of spaces before trailing line comments (<code>//</code> - comments).<p>This does not affect trailing block comments (<code>/*</code> - comments) as those commonly have different usage patterns and a number of special cases.<pre>SpacesBeforeTrailingComments: 3<br/>void f() {<br/>  if (true) {   // foo1<br/>    f();        // bar<br/>  }             // foo<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="SpaceBeforeTrailingComments: "
+MaxVal=100
+MinVal=0
+Value=1
+ValueDefault=1
+
+[SpacesInAngles]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted after &lt; and before &gt; in template argument lists.<pre>true:                                  false:<br/>static_cast&lt; int &gt;(arg);       vs.     static_cast&lt;int&gt;(arg);<br/>std::function&lt; void(int) &gt; fct;        std::function&lt;void(int)&gt; fct;</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInAngles: true|SpacesInAngles: false"
+Value=0
+ValueDefault=0
+
+[SpacesInCStyleCastParentheses]
+Category=5
+Description="<html>If <code>true</code>, spaces may be inserted into C style casts.<pre>true:                                  false:<br/>x = ( int32 )y                 vs.     x = (int32)y</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInCStyleCastParentheses: true|SpacesInCStyleCastParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpacesInContainerLiterals]
+Category=5
+Description="<html>If <code>true</code>, spaces are inserted inside container literals (e.g. ObjC and Javascript array and <code>dict</code> literals).<pre>true:                                  false:<br/>var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];<br/>f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3});</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInContainerLiterals: true|SpacesInContainerLiterals: false"
+Value=0
+ValueDefault=0
+
+[SpacesInParentheses]
+Category=5
+Description="<html>If true, spaces will be inserted after ( and before ).<pre>true:                                  false:<br/>t f( Deleted & ) & = delete;   vs.     t f(Deleted &) & = delete;</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInParentheses: true|SpacesInParentheses: false"
+Value=0
+ValueDefault=0
+
+[SpacesInSquareBrackets]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted after <code>[</code> and before <code>]</code>. Lambdas or unspecified size array declarations will not be affected.<pre>true:                                  false:<br/>int a[ 5 ];                    vs.     int a[5];<br/>std::unique_ptr&lt;int[]&gt; foo() {} // Won't be affected</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInSquareBrackets: true|SpacesInSquareBrackets: false"
+Value=0
+ValueDefault=0
+
+[Standard]
+Category=0
+Description="<html>(Standard)Format compatible with this standard, e.g. use <code>A&lt;A&lt;int&gt; &gt;</code> instead of <code>A&lt;A&lt;int&gt;&gt;</code> for </code>Cpp03</code>.</html>"
+EditorType=multiple
+Enabled=false
+Choices="Standard: Cpp03|Standard: Cpp11|Standard: Auto"
+ChoicesReadable="(Cpp03) Use C++03-compatible syntax.|(Cpp11) Use features of C++11, C++14 and C++1z (e.g. A<A<int>> instead of A<A<int> >).|(Auto) Automatic detection based on the input."
+ValueDefault=2
+
+[TabWidth]
+Category=3
+Description="<html>The number of columns used for tab stops.</html>"
+EditorType=numeric
+Enabled=false
+CallName="TabWidth: "
+MaxVal=100
+MinVal=0
+Value=8
+ValueDefault=8
+
+[UseTab]
+Category=3
+Description="<html>(UseTab) The way to use tab characters in the resulting file.</html>"
+EditorType=multiple
+Enabled=false
+Choices="UseTab: Never|UseTab: ForIndentation|UseTab: ForContinuationAndIndentation|UseTab: Always"
+ChoicesReadable="(Never) Never use tab.|(ForIndentation) Use tabs only for indentation.|(ForContinuationAndIndentation) Use tabs only for line continuation and indentation.|(Always) Use tabs whenever we need to fill whitespace that spans at least from one tab stop to the next one."
+ValueDefault=0

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#, Verilog)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/17.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=16.0.0
+version=17.0.0
 
 [Language]
 Category=0
@@ -51,12 +51,12 @@ Description="<html>(AlignAfterOpenBracket) Horizontally aligns arguments after a
 EditorType=multiple
 Enabled=false
 Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak|AlignAfterOpenBracket: BlockIndent"
-ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line.|(BlockIndent) Always break after an open bracket, if the parameters don't fit on a single line. Closing brackets will be placed on a new line. Note: This currently only applies to parentheses."
+ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line.|(BlockIndent) Always break after an open bracket, if the parameters don't fit on a single line. Closing brackets will be placed on a new line. Note: This currently only applies to braced initializer lists (when Cpp11BracedListStyle is true) and parentheses."
 ValueDefault=0
 
 [AlignArrayOfStructures]
 Category=4
-Description="<html>(AlignArrayOfStructures) if not <code>None</code>, when using initialization for an array of structs aligns the fields into columns.<p>NOTE: As of clang-format 15 this option only applied to arrays with equal number of columns per row.</p></html>"
+Description="<html>(AlignArrayOfStructures) if not <code>None</code>, when using initialization for an array of structs aligns the fields into columns.<p><b>Note</b><br/>As of clang-format 15 this option only applied to arrays with equal number of columns per row.</p></html>"
 EditorType=multiple
 Enabled=false
 Choices="AlignArrayOfStructures: Left|AlignArrayOfStructures: Right|AlignArrayOfStructures: None"
@@ -138,6 +138,46 @@ Choices="AlignConsecutiveMacros: None|AlignConsecutiveMacros: Consecutive|AlignC
 ChoicesReadable="(None) Do not align macro definitions on consecutive lines.|(Consecutive) Align macro definitions on consecutive lines.|(AcrossEmtpyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments)  Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments)  Same as Consecutive, but also spans over lines only containing comments and empty lines."
 ValueDefault=0
 
+[AlignConsecutiveShortCaseStatements]
+Category=4
+Description="<html>Style of aligning consecutive short case labels. Only applies if <code>AllowShortCaseLabelsOnASingleLine</code> is <code>true</code>.<pre># Example of usage:<br/>AlignConsecutiveShortCaseStatements:<br/>  Enabled: true<br/>  AcrossEmptyLines: true<br/>AcrossComments: true<br/>AlignCaseColons: false</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveShortCaseStatements:|AlignConsecutiveShortCaseStatements:"
+Value=1
+ValueDefault=1
+
+[ - Enabled (AlignConsecutiveShortCaseStatements)]
+Category=4
+Description="<html>Whether aligning is enabled.<pre>true:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/>default:           return "";<br/>}<br/><br/>false:<br/>switch (level) {<br/>case log::info: return "info:";<br/>case log::warning: return "warning:";<br/>default: return "";<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    Enabled: true|    Enabled: false"
+Value=0
+ValueDefault=0
+
+[ - AcrossEmptyLines (AlignConsecutiveShortCaseStatements)]
+Category=4
+Description="<html>Whether to align across empty lines.<pre>true:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/><br/>default:           return "";<br/>}<br/><br/>false:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/>default: return "";<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AcrossEmptyLines: true|    AcrossEmptyLines: false"
+Value=0
+ValueDefault=0
+
+[ - AcrossComments (AlignConsecutiveShortCaseStatements)]
+Category=4
+Description="<html>Whether to align across comments.<pre>true:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/>/* A comment. */<br/>default:           return "";<br/>}<br/><br/>false:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/>/* A comment. */<br/>default: return "";<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AcrossComments: true|    AcrossComments: false"
+Value=0
+ValueDefault=0
+
+[ - AlignCaseColons (AlignConsecutiveShortCaseStatements)]
+Category=4
+Description="<html>Whether aligned case labels are aligned on the colon, or on the , or on the tokens after the colon.<pre>true:<br/>switch (level) {<br/>case log::info   : return "info:";<br/>case log::warning: return "warning:";<br/>default          : return "";<br/>}<br/><br/>false:<br/>switch (level) {<br/>case log::info:    return "info:";<br/>case log::warning: return "warning:";<br/>default:           return "";<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="    AlignCaseColons: true|    AlignCaseColons: false"
+Value=0
+ValueDefault=0
+
 [AlignEscapedNewlines]
 Category=4
 Description="<html>(AlignEscapedNewlines) Options for aligning backslashes in escaped newlines.</html>"
@@ -158,7 +198,7 @@ ValueDefault=1
 
 [AlignTrailingComments]
 Category=4
-Description="<html>Control of trailing comments.<p>NOTE: As of clang-format 16 this option is not a bool but can be set to the options. Conventional bool options still can be parsed as before.</p><pre># Example of usage:<br/>AlignTrailingComments:<br/>  Kind: Always<br/>  OverEmptyLines: 2</pre></html>"
+Description="<html>Control of trailing comments.<p><b>Note</b><br/>As of clang-format 16 this option is not a bool but can be set to the options. Conventional bool options still can be parsed as before.</p><pre># Example of usage:<br/>AlignTrailingComments:<br/>  Kind: Always<br/>  OverEmptyLines: 2</pre></html>"
 EditorType=boolean
 TrueFalse="AlignTrailingComments:|AlignTrailingComments:"
 Value=1
@@ -396,7 +436,7 @@ ValueDefault=0
 
 [ - AfterObjCDeclaration]
 Category=2
-Description="<html>Wrap ObjC definitions (interfaces, implementations…). <code>@autoreleasepool</code> and <code>@synchronized</code> blocks are wrapped according to <code>AfterControlStatement</code> flag.</html>"
+Description="<html>Wrap ObjC definitions (interfaces, implementations…).<p><b>Note</b><br/><code>@autoreleasepool</code> and <code>@synchronized</code> blocks are wrapped according to <code>AfterControlStatement</code> flag.</p></html>"
 EditorType=boolean
 TrueFalse="    AfterObjCDeclaration: true|    AfterObjCDeclaration: false"
 Value=0
@@ -490,6 +530,17 @@ TrueFalse="    SplitEmptyNamespace: true|    SplitEmptyNamespace: false"
 Value=1
 ValueDefault=1
 
+[BracedInitializerIndentWidth]
+Category=3
+Description="<html>The number of columns to use to indent the contents of braced init lists. If unset, <code>ContinuationIndentWidth</code> is used.<pre>AlignAfterOpenBracket: AlwaysBreak<br/>BracedInitializerIndentWidth: 2<br/><br/>void f() {<br/>  SomeClass c{<br/>    "foo",<br/>    "bar",<br/>    "baz",<br/>  };<br/>  auto s = SomeStruct{<br/>    .foo = "foo",<br/>    .bar = "bar",<br/>    .baz = "baz",<br/>  };<br/>  SomeArrayT a[3] = {<br/>    {<br/>      foo,<br/>      bar,<br/>    },<br/>    {<br/>      foo,<br/>      bar,<br/>    },<br/>    SomeArrayT{},<br/>  };<br/>}</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="BracedInitializerIndentWidth: "
+MaxVal=2000
+MinVal=0
+Value=4
+ValueDefault=4
+
 [BreakAfterAttributes]
 Category=1
 Description="<html>(BreakAfterAttributes) Break after a group of C++11 attributes before a function declaration/definition name.</html>"
@@ -509,7 +560,7 @@ ValueDefault=0
 
 [BreakArrays]
 Category=1
-Description="<html>If <code>true</code>, clang-format will always break after a Json array <code>[</code> otherwise it will scan until the closing <code>]</code> to determine if it should add newlines between elements (prettier compatible).<br/><br/>NOTE: This is currently only for formatting JSON.<pre>true:                                  false:<br/>[                          vs.      [1, 2, 3, 4]<br/>  1,<br/>  2,<br/>  3,<br/>  4<br/>]</pre></html>"
+Description="<html>If <code>true</code>, clang-format will always break after a Json array <code>[</code> otherwise it will scan until the closing <code>]</code> to determine if it should add newlines between elements (prettier compatible).<p><b>Note</b><br/>This is currently only for formatting JSON.</p><pre>true:                                  false:<br/>[                          vs.      [1, 2, 3, 4]<br/>  1,<br/>  2,<br/>  3,<br/>  4<br/>]</pre></html>"
 EditorType=boolean
 TrueFalse="BreakArrays: true|BreakArrays: false"
 Value=1
@@ -539,7 +590,7 @@ Description="<html>(BreakBeforeConceptDeclarations) The concept declaration styl
 EditorType=multiple
 Enabled=false
 Choices="BreakBeforeConceptDeclarations: Never|BreakBeforeConceptDeclarations: Allowed|BreakBeforeConceptDeclarations: Always"
-ChoicesReadable="(Never) Keep the template declaration line together with `concept`.|(Allowed) Breaking between template declaration and `concept` is allowed. The actual behavior depends on the content and line breaking rules and penalities.|(Always) Always break before `concept`, putting it in the line after the template declaration."
+ChoicesReadable="(Never) Keep the template declaration line together with `concept`.|(Allowed) Breaking between template declaration and `concept` is allowed. The actual behavior depends on the content and line breaking rules and penalties.|(Always) Always break before `concept`, putting it in the line after the template declaration."
 ValueDefault=2
 
 [BreakBeforeInlineASMColon]
@@ -842,7 +893,7 @@ ValueDefault=0
 
 [IntegerLiteralSeparator]
 Category=7
-Description="<html>Format integer literal separators (<code>'</code> for C++ and <code>_</code> for C#, Java, and JavaScript).<p>Nested configuration flags:</p><p>Separator format of integer literals of different bases.</p><p>If negative, remove separators. If <code>0</code>, leave the literal as is. If positive, insert separators between digits starting from the rightmost digit.</p><p>For example, the config below will leave separators in binary literals alone, insert separators in decimal literals to separate the digits into groups of 3, and remove separators in hexadecimal literals.</p><pre>IntegerLiteralSeparator:<br/>  Binary: 0<br/>  Decimal: 3<br/>  Hex: -1</pre></html>"
+Description="<html>Format integer literal separators (<code>'</code> for C++ and <code>_</code> for C#, Java, and JavaScript).<p>Nested configuration flags:</p><p>Separator format of integer literals of different bases.</p><p>If negative, remove separators. If <code>0</code>, leave the literal as is. If positive, insert separators between digits starting from the rightmost digit.</p><p>For example, the config below will leave separators in binary literals alone, insert separators in decimal literals to separate the digits into groups of 3, and remove separators in hexadecimal literals.</p><pre>IntegerLiteralSeparator:<br/>  Binary: 0<br/>  Decimal: 3<br/>  Hex: -1</pre><p>You can also specify a minimum number of digits (<code>BinaryMinDigits</code>, <code>DecimalMinDigits</code>, and <code>HexMinDigits</code>) the integer literal must have in order for the separators to be inserted.</p></html>"
 EditorType=boolean
 TrueFalse="IntegerLiteralSeparator:|IntegerLiteralSeparator:"
 Value=1
@@ -859,6 +910,17 @@ MinVal=-256
 Value=0
 ValueDefault=0
 
+[ - BinaryMinDigits]
+Category=7
+Description="<html>Format separators in binary literals with a minimum number of digits.<pre>// Binary: 3<br/>// BinaryMinDigits: 7<br/>b1 = 0b101101;<br/>b2 = 0b1'101'101;</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="    BinaryMinDigits: "
+MaxVal=255
+MinVal=-256
+Value=0
+ValueDefault=0
+
 [ - Decimal]
 Category=7
 Description="<html>Format separators in decimal literals.</html>"
@@ -870,12 +932,34 @@ MinVal=-256
 Value=0
 ValueDefault=0
 
+[ - DecimalMinDigits]
+Category=7
+Description="<html>Format separators in decimal literals with a minimum number of digits.<pre>// Decimal: 3<br/>// DecimalMinDigits: 5<br/>d1 = 2023;<br/>d2 = 10'000;</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="    DecimalMinDigits: "
+MaxVal=255
+MinVal=-256
+Value=0
+ValueDefault=0
+
 [ - Hex]
 Category=7
 Description="<html>Format separators in hexadecimal literals.</html>"
 EditorType=numeric
 Enabled=false
 CallName="    Hex: "
+MaxVal=255
+MinVal=-256
+Value=0
+ValueDefault=0
+
+[ - HexMinDigits]
+Category=7
+Description="<html>Format separators in hexadecimal literals with a minimum number of digits.<pre>// Hex: 2<br/>// HexMinDigits: 6<br/>h1 = 0xABCDE;<br/>h2 = 0xAB'CD'EF;</pre></html>"
+EditorType=numeric
+Enabled=false
+CallName="    HexMinDigits: "
 MaxVal=255
 MinVal=-256
 Value=0
@@ -904,6 +988,14 @@ Category=1
 Description="<html>Whether to wrap JavaScript <code>import</code>/<code>export</code> statements.<pre>true:<br/>import {<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>    VeryLongImportsAreAnnoying,<br/>} from 'some/module.js'<br/><br/>false:<br/>import {VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying, VeryLongImportsAreAnnoying,} from &quot;some/module.js&quot;</pre></html>"
 EditorType=boolean
 TrueFalse="JavaScriptWrapImports: true|JavaScriptWrapImports: false"
+Value=0
+ValueDefault=0
+
+[KeepEmptyLinesAtEOF]
+Category=6
+Description="<html>Keep empty lines (up to <code>MaxEmptyLinesToKeep</code>) at end of file.</html>"
+EditorType=boolean
+TrueFalse="KeepEmptyLinesAtEOF: true|KeepEmptyLinesAtEOF: false"
 Value=0
 ValueDefault=0
 
@@ -950,6 +1042,15 @@ CallName="MacroBlockEnd: "
 Enabled=false
 Value="''"
 ValueDefault="''"
+
+[Macros]
+Category=7
+Description="<html>A list of macros of the form <code>&lt;definition&gt;=&lt;expansion&gt;</code>.<p>Code will be parsed with macros expanded, in order to determine how to interpret and format the macro arguments.</p><p>For example, the code:<pre>A(a*b);</pre>will usually be interpreted as a call to a function A, and the multiplication expression will be formatted as <code>a * b</code>.</p><p>If we specify the macro definition:<pre>Macros:<br/>- A(x)=x</pre>the code will now be parsed as a declaration of the variable b of type a*, and formatted as <code>a* b</code> (depending on pointer-binding rules).</p><p>Features and restrictions:<ul><li>Both function-like macros and object-like macros are supported.</li><li>Macro arguments must be used exactly once in the expansion.</li><li>No recursive expansion; macros referencing other macros will be ignored.</li><li>Overloading by arity is supported: for example, given the macro definitions A=x, A()=y, A(a)=a<pre>A; -&gt; x;<br/>A(); -&gt; y;<br/>A(z); -&gt; z;<br/>A(a, b); // will not be expanded.</pre></li></ul></p></html>"
+EditorType=string
+CallName="Macros: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
 
 [MaxEmptyLinesToKeep]
 Category=6
@@ -1029,8 +1130,8 @@ Category=1
 Description="<html>(PackConstructorInitializers) The pack constructor initializers style to use.</html>"
 EditorType=multiple
 Enabled=false
-Choices="PackConstructorInitializers: Never|PackConstructorInitializers: BinPack|PackConstructorInitializers: CurrentLine|PackConstructorInitializers: NextLine"
-ChoicesReadable="(Never) Always put each constructor initializer on its own line.|(BinPack) Bin-pack constructor initializers.|(CurrentLine) Put all constructor initializers on the current line if they fit. Otherwise, put each one on its own line.|(NextLine) Same as CurrentLine except that if all constructor initializers do not fit on the current line, try to fit them on the next line."
+Choices="PackConstructorInitializers: Never|PackConstructorInitializers: BinPack|PackConstructorInitializers: CurrentLine|PackConstructorInitializers: NextLine|PackConstructorInitializers: NextLineOnly"
+ChoicesReadable="(Never) Always put each constructor initializer on its own line.|(BinPack) Bin-pack constructor initializers.|(CurrentLine) Put all constructor initializers on the current line if they fit. Otherwise, put each one on its own line.|(NextLine) Same as CurrentLine except that if all constructor initializers do not fit on the current line, try to fit them on the next line.|(NextLineOnly) Put all constructor initializers on the next line if they fit. Otherwise, put each one on its own line."
 ValueDefault=1
 
 [PenaltyBreakAssignment]
@@ -1174,7 +1275,7 @@ ValueDefault=0
 
 [QualifierOrder]
 Category=7
-Description="<html>The order in which the qualifiers appear.<p>Order is an array that can contain any of the following:<ul><li>const</li><li>inline</li><li>static</li><li>friend</li><li>constexpr</li><li>volatile</li><li>restrict</li><li>type</li></ul>Note: it MUST contain 'type'.<br/>Items to the left of 'type' will be placed to the left of the type and aligned in the order supplied. Items to the right of 'type' will be placed to the right of the type and aligned in the order supplied.</html>"
+Description="<html>The order in which the qualifiers appear.<p>Order is an array that can contain any of the following:<ul><li>const</li><li>inline</li><li>static</li><li>friend</li><li>constexpr</li><li>volatile</li><li>restrict</li><li>type</li></ul><p><b>Note</b><br/>it MUST contain 'type'.</p><p>Items to the left of 'type' will be placed to the left of the type and aligned in the order supplied. Items to the right of 'type' will be placed to the right of the type and aligned in the order supplied.</p></html>"
 EditorType=string
 CallName="QualifierOrder: "
 Enabled=false
@@ -1204,6 +1305,15 @@ Description="<html>Remove optional braces of control statements (<code>if</code>
 EditorType=boolean
 TrueFalse="RemoveBracesLLVM: true|RemoveBracesLLVM: false"
 Value=0
+ValueDefault=0
+
+[RemoveParentheses]
+Category=7
+Description="<html>(RemoveParentheses) Remove redundant parentheses.<p><b>Warning</b><br/>Setting this option to any value other than <code>Leave</code> could lead to incorrect code formatting due to clang-format's lack of complete semantic information. As such, extra care should be taken to review code changes made by this option.</p></html>"
+EditorType=multiple
+Enabled=false
+Choices="RemoveParentheses: Leave|RemoveParentheses: MultipleParentheses|RemoveParentheses: ReturnStatement"
+ChoicesReadable="(Leave) Do not remove parentheses.|(MultipleParentheses) Replace multiple parentheses with single parentheses.|(ReturnStatement) Also remove parentheses enclosing the expression in a return/co_return statement."
 ValueDefault=0
 
 [RemoveSemicolon]
@@ -1353,6 +1463,14 @@ TrueFalse="SpaceBeforeInheritanceColon: true|SpaceBeforeInheritanceColon: false"
 Value=1
 ValueDefault=1
 
+[SpaceBeforeJsonColon]
+Category=5
+Description="<html>If <code>true</code>, a space will be add before a JSON colon. For other languages, e.g. JavaScript, use <code>SpacesInContainerLiterals</code> instead.<pre>true:                                  false:<br/>{                                      {<br/>  "key" : "value"              vs.       "key": "value"<br/>}                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeJsonColon: true|SpaceBeforeJsonColon: false"
+Value=0
+ValueDefault=0
+
 [SpaceBeforeParens]
 Category=5
 Description="<html>(SpaceBeforeParens) Defines in which cases to put a space before opening parentheses.</html>"
@@ -1466,17 +1584,9 @@ TrueFalse="SpaceInEmptyBlock: true|SpaceInEmptyBlock: false"
 Value=0
 ValueDefault=0
 
-[SpaceInEmptyParentheses]
-Category=5
-Description="<html>If <code>true</code>, spaces may be inserted into <code>()</code>.<pre>true:                                false:<br/>void f( ) {                    vs.   void f() {<br/>  int x[] = {foo( ), bar( )};          int x[] = {foo(), bar()};<br/>  if (true) {                          if (true) {<br/>    f( );                                f();<br/>  }                                    }<br/>}                                    }</pre></html>"
-EditorType=boolean
-TrueFalse="SpaceInEmptyParentheses: true|SpaceInEmptyParentheses: false"
-Value=0
-ValueDefault=0
-
 [SpaceBeforeTrailingComments]
 Category=5
-Description="<html>The number of spaces before trailing line comments (<code>//</code> - comments).<p>This does not affect trailing block comments (<code>/*</code> - comments) as those commonly have different usage patterns and a number of special cases.<pre>SpacesBeforeTrailingComments: 3<br/>void f() {<br/>  if (true) {   // foo1<br/>    f();        // bar<br/>  }             // foo<br/>}</pre></html>"
+Description="<html>The number of spaces before trailing line comments (<code>//</code> - comments).<p>This does not affect trailing block comments (<code>/*</code> - comments) as those commonly have different usage patterns and a number of special cases. In the case of Verilog, it doesn't affect a comment right after the opening parenthesis in the port or parameter list in a module header, because it is probably for the port on the following line instead of the parenthesis it follows.<pre>SpacesBeforeTrailingComments: 3<br/>void f() {<br/>  if (true) {   // foo1<br/>    f();        // bar<br/>  }             // foo<br/>}</pre></html>"
 EditorType=numeric
 Enabled=false
 CallName="SpaceBeforeTrailingComments: "
@@ -1494,25 +1604,9 @@ Choices="SpacesInAngles: Never|SpacesInAngles: Always|SpacesInAngles: Leave"
 ChoicesReadable="(Never) Remove spaces after < and before >.|(Always) Add spaces after < and before >.|(Leave) Keep a single space after < and before > if any spaces were present. Option 'Standard: Cpp03' takes precedence."
 ValueDefault=0
 
-[SpacesInCStyleCastParentheses]
-Category=5
-Description="<html>If <code>true</code>, spaces may be inserted into C style casts.<pre>true:                                  false:<br/>x = ( int32 )y                 vs.     x = (int32)y</pre></html>"
-EditorType=boolean
-TrueFalse="SpacesInCStyleCastParentheses: true|SpacesInCStyleCastParentheses: false"
-Value=0
-ValueDefault=0
-
-[SpacesInConditionalStatement]
-Category=5
-Description="<html>If <code>true</code>, spaces will be inserted around if/for/switch/while conditions.<pre>true:                                  false:<br/>if ( a )  { ... }              vs.     if (a) { ... }<br/>while ( i < 5 )  { ... }               while (i < 5) { ... }</pre></html>"
-EditorType=boolean
-TrueFalse="SpacesInConditionalStatement: true|SpacesInConditionalStatement: false"
-Value=0
-ValueDefault=0
-
 [SpacesInContainerLiterals]
 Category=5
-Description="<html>If <code>true</code>, spaces are inserted inside container literals (e.g. ObjC and Javascript array and <code>dict</code> literals).<pre>true:                                  false:<br/>var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];<br/>f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3});</pre></html>"
+Description="<html>If <code>true</code>, spaces are inserted inside container literals (e.g. ObjC and Javascript array and <code>dict</code> literals). For JSON, use <code>SpaceBeforeJsonColon</code> instead.<pre>true:                                  false:<br/>var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];<br/>f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3});</pre></html>"
 EditorType=boolean
 TrueFalse="SpacesInContainerLiterals: true|SpacesInContainerLiterals: false"
 Value=0
@@ -1548,11 +1642,51 @@ MinVal=-1
 Value=-1
 ValueDefault=-1
 
-[SpacesInParentheses]
+[SpacesInParens]
 Category=5
-Description="<html>If true, spaces will be inserted after ( and before ).<pre>true:                                  false:<br/>t f( Deleted & ) & = delete;   vs.     t f(Deleted &) & = delete;</pre></html>"
+Description="<html>Defines in which cases spaces will be inserted after <code>(</code> and before <code>)</code>.<p>Possible values:<ul><li><code>Never</code><br/>Never put a space in parentheses.</li><li><code>Custom</code><br/>Configure each individual space in parentheses in <code>SpacesInParensOptions</code>.</li></ul></p></html>"
 EditorType=boolean
-TrueFalse="SpacesInParentheses: true|SpacesInParentheses: false"
+TrueFalse="SpacesInParens: Custom|SpacesInParens: Never"
+Value=0
+ValueDefault=0
+
+[SpacesInParensOptions]
+Category=5
+Description="<html>Control of individual spaces in parentheses.<p>If <code>SpacesInParens</code> is set to <code>Custom</code>, use this to specify how each individual space in parentheses case should be handled. Otherwise this is ignored.</p><pre># Example of usage:<br/>SpacesInParens: Custom<br/>SpacesInParensOptions:<br/>  InConditionalStatements: true<br/>  InEmptyParentheses: true</pre></html>"
+EditorType=boolean
+TrueFalse="SpacesInParensOptions:|SpacesInParensOptions"
+Value=0
+ValueDefault=0
+
+[ - InConditionalStatements (SpacesInParensOptions)]
+Category=5
+Description="<html>Put a space in parentheses only inside conditional statements (<code>for/if/while/switch...</code>).<pre>true:                                  false:<br/>if ( a )  { ... }              vs.     if (a) { ... }<br/>while ( i < 5 )  { ... }               while (i < 5) { ... }</pre></html>"
+EditorType=boolean
+TrueFalse="    InConditionalStatements: true|    InConditionalStatements: false"
+Value=0
+ValueDefault=0
+
+[ - InCStyleCasts (SpacesInParensOptions)]
+Category=5
+Description="<html>Put a space in C style casts.<pre>true:                                  false:<br/>x = ( int32 )y                 vs.     x = (int32)y</pre></html>"
+EditorType=boolean
+TrueFalse="    InCStyleCasts: true|    InCStyleCasts: false"
+Value=0
+ValueDefault=0
+
+[ - InEmptyParentheses (SpacesInParensOptions)]
+Category=5
+Description="<html>Put a space in parentheses only if the parentheses are empty i.e. '()'<pre>true:                                false:<br/>void f( ) {                    vs.   void f() {<br/>  int x[] = {foo( ), bar( )};          int x[] = {foo(), bar()};<br/>  if (true) {                          if (true) {<br/>    f( );                                f();<br/>  }                                    }<br/>}                                    }</pre></html>"
+EditorType=boolean
+TrueFalse="    InEmptyParentheses: true|    InEmptyParentheses: false"
+Value=0
+ValueDefault=0
+
+[ - Other (SpacesInParensOptions)]
+Category=5
+Description="<html>Put a space in parentheses not covered by preceding options.<pre>true:                                  false:<br/>t f( Deleted & ) & = delete;   vs.     t f(Deleted &) & = delete;</pre></html>"
+EditorType=boolean
+TrueFalse="    Other: true|    Other: false"
 Value=0
 ValueDefault=0
 
@@ -1602,6 +1736,16 @@ MinVal=0
 Value=8
 ValueDefault=8
 
+[TypeNames]
+Category=5
+Description="<html>A vector of non-keyword identifiers that should be interpreted as type names.<p>A <code>*</code>, <code>&amp;</code>, or <code>&amp;&amp;</code> between a type name and another non-keyword identifier is annotated as a pointer or reference token instead of a binary operator.</p></html>"
+LIST_ENTRY.</html>"
+EditorType=string
+CallName="TypeNames: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
+
 [TypenameMacros]
 Category=7
 Description="<html>A vector of macros that should be interpreted as type declarations instead of as function calls.<p>These are expected to be macros of the form:<pre>STACK_OF(...)</pre><p>In the <code>.clang-format</code> configuration file, this can be configured like: <pre>TypenameMacros: ['STACK_OF', 'LIST']</pre><p>For example: OpenSSL STACK_OF, BSD LIST_ENTRY.</html>"
@@ -1619,6 +1763,14 @@ Enabled=false
 Choices="UseTab: Never|UseTab: ForIndentation|UseTab: ForContinuationAndIndentation|UseTab: Always"
 ChoicesReadable="(Never) Never use tab.|(ForIndentation) Use tabs only for indentation.|(ForContinuationAndIndentation) Fill all leading whitespace with tabs, and use spaces for alignment that appears within a line (e.g. consecutive assignments and declarations).|(AlignWithSpaces) Use tabs for line continuation and indentation, and spaces for alignment.|(Always) Use tabs whenever we need to fill whitespace that spans at least from one tab stop to the next one."
 ValueDefault=0
+
+[VerilogBreakBetweenInstancePorts]
+Category=1
+Description="<html>For Verilog, put each port on its own line in module instantiations.<pre>true:<br/>ffnand ff1(.q(),<br/>           .qbar(out1),<br/>           .clear(in1),<br/>           .preset(in2));<br/><br/>false:<br/>ffnand ff1(.q(), .qbar(out1), .clear(in1), .preset(in2));</pre></html>"
+EditorType=boolean
+TrueFalse="VerilogBreakBetweenInstancePorts: true|VerilogBreakBetweenInstancePorts: false"
+Value=1
+ValueDefault=1
 
 [WhitespaceSensitiveMacros]
 Category=7

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,7 +7,7 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
@@ -31,7 +31,7 @@ Description="<html>(BasedOnStyle) The style used for all options not specificall
 EditorType=multiple
 Enabled=false
 Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft"
-ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017"
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017"
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -129,10 +129,11 @@ ValueDefault=1
 
 [AllowShortBlocksOnASingleLine]
 Category=1
-Description="<html>Allows contracting simple braced statements to a single line.<p>E.g., this allows <code>if (a) { return; }</code> to be put on a single line (if <code>AllowShortIfStatementsOnASingleLine</code> is also enabled).</html>"
-EditorType=boolean
-TrueFalse="AllowShortBlocksOnASingleLine: true|AllowShortBlocksOnASingleLine: false"
-Value=0
+Description="<html>(AllowShortBlocksOnASingleLine) Allows contracting simple braced statements to a single line.<p>E.g., this allows <code>if (a) { return; }</code> to be put on a single line (if <code>AllowShortIfStatementsOnASingleLine</code> is also enabled).</html>"
+EditorType=multiple
+Enabled=false
+Choices="AllowShortBlocksOnASingleLine: Never|AllowShortBlocksOnASingleLine: Empty|AllowShortBlocksOnASingleLine: Always"
+ChoicesReadable="(Never) Never merge blocks into a single line.|(Empty) Only merge empty blocks.|(Always) Always merge short blocks into a single line."
 ValueDefault=0
 
 [AllowShortCaseLabelsOnASingleLine]
@@ -246,10 +247,11 @@ ValueDefault=0
 
 [ - AfterControlStatement]
 Category=2
-Description="<html>Wrap control statements (<code>if</code>/<code>for</code>/<code>while</code>/<code>switch</code>/..).<pre>true:<br/>if (foo())<br/>{<br/>} else<br/>{}<br/>for (int i = 0; i &lt; 10; ++i)<br/>{}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}<br/>for (int i = 0; i &lt; 10; ++i) {<br/>}</pre></html>"
-EditorType=boolean
-TrueFalse="    AfterControlStatement: true|    AfterControlStatement: false"
-Value=0
+Description="<html>( - AfterControlStatement) Wrap control statements (<code>if</code>/<code>for</code>/<code>while</code>/<code>switch</code>/..).</html>"
+EditorType=multiple
+Enabled=false
+Choices="    AfterControlStatement: Never|    AfterControlStatement: MultiLine|    AfterControlStatement: Always"
+ChoicesReadable="(Never) Never wrap braces after a control statement.|(MultiLine) Only wrap braces after a multi-line control statement.|(Always) Always wrap braces after a control statement."
 ValueDefault=0
 
 [ - AfterEnum]
@@ -334,7 +336,7 @@ ValueDefault=0
 
 [ - SplitEmptyFunction]
 Category=2
-Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>int f()   vs.   inf f()<br/>{}              {<br/>                }</pre></html>"
+Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>int f()   vs.   int f()<br/>{}              {<br/>                }</pre></html>"
 EditorType=boolean
 TrueFalse="    SplitEmptyFunction: true|    SplitEmptyFunction: false"
 Value=1
@@ -378,8 +380,8 @@ Category=2
 Description="<html>(BreakBeforeBraces) The brace breaking style to use.</html>"
 EditorType=multiple
 Enabled=false
-Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: Mozilla|BreakBeforeBraces: Stroustrup|BreakBeforeBraces: Allman|BreakBeforeBraces: GNU|BreakBeforeBraces: WebKit|BreakBeforeBraces: Custom"
-ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
+Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: Mozilla|BreakBeforeBraces: Stroustrup|BreakBeforeBraces: Allman|BreakBeforeBraces: Whitesmiths|BreakBeforeBraces: GNU|BreakBeforeBraces: WebKit|BreakBeforeBraces: Custom"
+ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(Whitesmiths) Like Allman but always indent braces and line up code with braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
 ValueDefault=0
 
 [BreakBeforeTernaryOperators]
@@ -410,7 +412,7 @@ ValueDefault=0
 
 [BreakStringLiterals]
 Category=1
-Description="<html>Allow breaking string literals when formatting.</html>"
+Description="<html>Allow breaking string literals when formatting.<pre>true:<br/>const char* x = "veryVeryVeryVeryVeryVe"<br/>                "ryVeryVeryVeryVeryVery"<br/>                "VeryLongString";<br/><br/>false:<br/>const char* x =<br/> "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString";</pre></html>"
 EditorType=boolean
 TrueFalse="BreakStringLiterals: true|BreakStringLiterals: false"
 Value=1
@@ -482,6 +484,14 @@ TrueFalse="Cpp11BracedListStyle: true|Cpp11BracedListStyle: false"
 Value=1
 ValueDefault=1
 
+[DeriveLineEnding]
+Category=7
+Description="<html>Analyze the formatted file for the most used line ending (<code>\r\n</code> or <code>\n</code>). <code>UseCRLF<code> is only used as a fallback if none can be derived.</html>"
+EditorType=boolean
+TrueFalse="DeriveLineEnding: true|DeriveLineEnding: false"
+Value=0
+ValueDefault=0
+
 [DerivePointerAlignment]
 Category=5
 Description="<html>If <code>true</code>, analyze the formatted file for the most common alignment of <code>&</code> and <code>*</code>. Pointer and reference alignment styles are going to be updated according to the preferences found in the file. <code>PointerAlignment</code> is then used only as fallback.</html>"
@@ -533,6 +543,15 @@ Enabled=false
 Value="''"
 ValueDefault="''"
 
+[IncludeIsMainSourceRegex]
+Category=7
+Description="<html>Specify a regular expression for files being formatted that are allowed to be considered "main" in the file-to-main-include mapping.<p>By default, clang-format considers files as "main" only when they end with: <code>.c</code>, <code>.cc</code>, <code>.cpp</code>, <code>.c++</code>, <code>.cxx</code>, <code>.m</code> or <code>.mm</code> extensions. For these files a guessing of "main" include takes place (to assign category 0, see above). This config option allows for additional suffixes and extensions for files to be considered as "main".</p><p>For example, if this option is configured to <code>(Impl\.hpp)$</code>, then a file <code>ClassImpl.hpp</code> is considered "main" (in addition to <code>Class.c</code>, <code>Class.cc</code>, <code>Class.cpp</code> and so on) and "main include file" logic will be executed (with <i>IncludeIsMainRegex</i> setting also being respected in later phase). Without this option set, <code>ClassImpl.hpp</code> would not have the main include file put on top before any other include.</p></html>"
+EditorType=string
+CallName="IncludeIsMainSourceRegex: "
+Enabled=false
+Value="''"
+ValueDefault="''"
+
 [IndentCaseLabels]
 Category=3
 Description="<html>Indent <code>case</code> labels one level from the <code>switch</code> statement.<p>When <code>false</code>, use the same indentation level as for the <code>switch</code> statement. Switch statement body is always indented one level more than <code>case</code> labels.<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1:                                  case 1:<br/>  bar();                                   bar();<br/>  break;                                   break;<br/>default:                                 default:<br/>  plop();                                  plop();<br/>}                                      }</pre></html>"
@@ -540,6 +559,14 @@ EditorType=boolean
 TrueFalse="IndentCaseLabels: true|IndentCaseLabels: false"
 Value=0
 ValueDefault=0
+
+[IndentGotoLabels]
+Category=3
+Description="<html>Indent goto labels.<p>When <code>false</code>, goto labels are flushed left.</p><pre>true:                                  false:<br/>int f() {                      vs.     int f() {<br/>  if (foo()) {                           if (foo()) {<br/>  label1:                              label1:<br/>    bar();                                 bar();<br/>  }                                      }<br/>label2:                                label2:<br/>  return 1;                              return 1;<br/>}                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="IndentGotoLabels: true|IndentGotoLabels: false"
+Value=1
+ValueDefault=1
 
 [IndentPPDirectives]
 Category=3
@@ -833,7 +860,7 @@ ValueDefault=1
 
 [SpaceBeforeAssignmentOperators]
 Category=5
-Description="<html>If <code>false</code>, spaces will be removed before assignment operators.<pre>true:                                  false:<br/>int a = 5;                     vs.     int a= 5;<br/>a += 42                                a+= 42;</pre></html>"
+Description="<html>If <code>false</code>, spaces will be removed before assignment operators.<pre>true:                                  false:<br/>int a = 5;                     vs.     int a= 5;<br/>a += 42;                               a+= 42;</pre></html>"
 EditorType=boolean
 TrueFalse="SpaceBeforeAssignmentOperators: true|SpaceBeforeAssignmentOperators: false"
 Value=1
@@ -880,6 +907,22 @@ TrueFalse="SpaceBeforeRangeBasedForLoopColon: true|SpaceBeforeRangeBasedForLoopC
 Value=1
 ValueDefault=1
 
+[SpaceBeforeSquareBrackets]
+Category=5
+Description="<html>If <code>true</code>, spaces will be before <code>[</code>. Lambdas will not be affected. Only the first <code>[</code> will get a space added.<pre>true:                                  false:<br/>int a [5];                    vs.      int a[5];<br/>int a [5][5];                 vs.      int a[5][5];</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeSquareBrackets: true|SpaceBeforeSquareBrackets: false"
+Value=0
+ValueDefault=0
+
+[SpaceInEmptyBlock]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted into <code>{}</code>.<pre>true:                                false:<br/>void f() { }                   vs.   void f() {}<br/>while (true) { }                     while (true) {}</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceInEmptyBlock: true|SpaceInEmptyBlock: false"
+Value=0
+ValueDefault=0
+
 [SpaceInEmptyParentheses]
 Category=5
 Description="<html>If <code>true</code>, spaces may be inserted into <code>()</code>.<pre>true:                                false:<br/>void f( ) {                    vs.   void f() {<br/>  int x[] = {foo( ), bar( )};          int x[] = {foo(), bar()};<br/>  if (true) {                          if (true) {<br/>    f( );                                f();<br/>  }                                    }<br/>}                                    }</pre></html>"
@@ -915,6 +958,14 @@ TrueFalse="SpacesInCStyleCastParentheses: true|SpacesInCStyleCastParentheses: fa
 Value=0
 ValueDefault=0
 
+[SpacesInConditionalStatement]
+Category=5
+Description="<html>If <code>true</code>, spaces will be inserted around if/for/while (and similar) conditions.</html>"
+EditorType=boolean
+TrueFalse="SpacesInConditionalStatement: true|SpacesInConditionalStatement: false"
+Value=0
+ValueDefault=0
+
 [SpacesInContainerLiterals]
 Category=5
 Description="<html>If <code>true</code>, spaces are inserted inside container literals (e.g. ObjC and Javascript array and <code>dict</code> literals).<pre>true:                                  false:<br/>var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];<br/>f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3});</pre></html>"
@@ -933,7 +984,7 @@ ValueDefault=0
 
 [SpacesInSquareBrackets]
 Category=5
-Description="<html>If <code>true</code>, spaces will be inserted after <code>[</code> and before <code>]</code>. Lambdas or unspecified size array declarations will not be affected.<pre>true:                                  false:<br/>int a[ 5 ];                    vs.     int a[5];<br/>std::unique_ptr&lt;int[]&gt; foo() {} // Won't be affected</pre></html>"
+Description="<html>If <code>true</code>, spaces will be inserted after <code>[</code> and before <code>]</code>. Lambdas without arguments or unspecified size array declarations will not be affected.<pre>true:                                  false:<br/>int a[ 5 ];                    vs.     int a[5];<br/>std::unique_ptr&lt;int[]&gt; foo() {} // Won't be affected</pre></html>"
 EditorType=boolean
 TrueFalse="SpacesInSquareBrackets: true|SpacesInSquareBrackets: false"
 Value=0
@@ -941,12 +992,12 @@ ValueDefault=0
 
 [Standard]
 Category=0
-Description="<html>(Standard)Format compatible with this standard, e.g. use <code>A&lt;A&lt;int&gt; &gt;</code> instead of <code>A&lt;A&lt;int&gt;&gt;</code> for </code>Cpp03</code>.</html>"
+Description="<html>(Standard) Parse and format C++ constructs compatible with this standard.<pre>c++03:                                 latest:<br/>vector&lt;set&lt;int> > x;           vs.     vector&lt;set&lt;int>> x;</pre></html>"
 EditorType=multiple
 Enabled=false
-Choices="Standard: Cpp03|Standard: Cpp11|Standard: Auto"
-ChoicesReadable="(Cpp03) Use C++03-compatible syntax.|(Cpp11) Use features of C++11, C++14 and C++1z (e.g. A<A<int>> instead of A<A<int> >).|(Auto) Automatic detection based on the input."
-ValueDefault=2
+Choices="Standard: c++03|Standard: c++11|Standard: c++14|Standard: c++17|Standard: c++20|Standard: Latest|Standard: Auto"
+ChoicesReadable="(c++03) Parse and format as C++03. 'Cpp03' is a deprecated alias for 'c++03'.|(c++11) Parse and format as C++11.|(c++14) Parse and format as C++14.|(c++17) Parse and format as C++17.|(c++20) Parse and format as C++20.|(Latest) Parse and format using the latest supported language version. 'Cpp11' is a deprecated alias for 'Latest'.|(Auto) Automatic detection based on the input."
+ValueDefault=6
 
 [StatementMacros]
 Category=7
@@ -976,6 +1027,14 @@ CallName="TypenameMacros: "
 Enabled=false
 Value="[]"
 ValueDefault="[]"
+
+[UseCRLF]
+Category=7
+Description="<html>Use <code>\r\n</code> instead of <code>\n</code> for line breaks. Also used as fallback if <code>DeriveLineEnding</code> is true.</html>"
+EditorType=boolean
+TrueFalse="UseCRLF: true|UseCRLF: false"
+Value=0
+ValueDefault=0
 
 [UseTab]
 Category=3

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -2,27 +2,27 @@
 categories="Overall Policy|Breaking and Joining|Brace Positioning|Indentation|Alignment|Horizontal Spacing|Vertical Spacing|Other Edits"
 cfgFileParameterEnding=cr
 configFilename=.clang-format
-fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.m|*.mm|*.M|*.proto
+fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.m|*.mm|*.M|*.proto|*.cs
 indenterFileName=clang-format
-indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf)
+indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=8.0.0
+version=9.0.0
 
 [Language]
 Category=0
 Description="<html>(Language) Language this format style is targeted at.</html>"
 EditorType=multiple
 Enabled=true
-Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen"
-ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen"
+Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen|Language: CSharp"
+ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen|(CSharp) C#"
 ValueDefault=0
 
 [BasedOnStyle]
@@ -30,8 +30,8 @@ Category=0
 Description="<html>(BasedOnStyle) The style used for all options not specifically set in the configuration.</html>"
 EditorType=multiple
 Enabled=false
-Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit"
-ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - http://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - http://www.webkit.org/coding/coding-style.html"
+Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft"
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017"
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -70,6 +70,14 @@ TrueFalse="AlignConsecutiveDeclarations: true|AlignConsecutiveDeclarations: fals
 Value=0
 ValueDefault=0
 
+[AlignConsecutiveMacros]
+Category=4
+Description="<html>If <code>true</code>, aligns consecutive C/C++ preprocessor macros.<p>This will align the C/C++ preprocessor macros of consecutive lines. This will result in formattings like<pre>#define SHORT_NAME       42<br/>#define LONGER_NAME      0x007f<br/>#define EVEN_LONGER_NAME (2)<br/>#define foo(x)           (x * x)<br/>#define bar(y, z)        (y + z)</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveMacros: true|AlignConsecutiveMacros: false"
+Value=0
+ValueDefault=0
+
 [AlignEscapedNewlines]
 Category=4
 Description="<html>(AlignEscapedNewlines) Options for aligning backslashes in escaped newlines.</html>"
@@ -92,6 +100,22 @@ Category=4
 Description="<html>Aligns trailing comments.<pre>true:                                   false:<br/>int a;     // My comment a      vs.     int a; // My comment a<br/>int b = 2; // comment  b                int b = 2; // comment about b</pre></html>"
 EditorType=boolean
 TrueFalse="AlignTrailingComments: true|AlignTrailingComments: false"
+Value=1
+ValueDefault=1
+
+[AllowAllArgumentsOnNextLine]
+Category=1
+Description="<html>If a function call or braced initializer list doesn’t fit on a line, allow putting all arguments onto the next line, even if <code>BinPackArguments</code> is <code>false</code>.<pre>true:<br/>callFunction(<br/>    a, b, c, d);<br/><br/>false:<br/>callFunction(a,<br/>             b,<br/>             c,<br/>             d);</pre></html>"
+EditorType=boolean
+TrueFalse="AllowAllArgumentsOnNextLine: true|AllowAllArgumentsOnNextLine: false"
+Value=1
+ValueDefault=1
+
+[AllowAllConstructorInitializersOnNextLine]
+Category=1
+Description="<html>If a constructor definition with a member initializer list doesn’t fit on a single line, allow putting all member initializers onto the next line, if <code>ConstructorInitializerAllOnOneLineOrOnePerLine</code> is true. Note that this parameter has no effect if <code>ConstructorInitializerAllOnOneLineOrOnePerLine</code> is false.<pre>true:<br/>MyClass::MyClass() :<br/>    member0(0), member1(2) {}<br/><br/>false:<br/>MyClass::MyClass() :<br/>    member0(0),<br/>    member1(2) {}</pre></html>"
+EditorType=boolean
+TrueFalse="AllowAllConstructorInitializersOnNextLine: true|AllowAllConstructorInitializersOnNextLine: false"
 Value=1
 ValueDefault=1
 
@@ -130,11 +154,21 @@ ValueDefault=4
 
 [AllowShortIfStatementsOnASingleLine]
 Category=1
-Description="<html><code>if (a) return;</code> can be put on a single line.<p>Note: If the statement body is a block then <code>AllowShortBlocksOnASingleLine</code> is also needed.</html>"
-EditorType=boolean
-TrueFalse="AllowShortIfStatementsOnASingleLine: true|AllowShortIfStatementsOnASingleLine: false"
-Value=0
+Description="<html>(AllowShortIfStatementsOnASingleLine) If <code>true</code>, <code>if (a) return;</code> can be put on a single line.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AllowShortIfStatementsOnASingleLine: Never|AllowShortIfStatementsOnASingleLine: WithoutElse|AllowShortIfStatementsOnASingleLine: Always"
+ChoicesReadable="(Never) Never put short ifs on the same line.|(WithoutElse) Without else put short ifs on the same line only if the else is not a compound statement.|(Always) Always put short ifs on the same line if the else is not a compound statement or not."
 ValueDefault=0
+
+[AllowShortLambdasOnASingleLine]
+Category=1
+Description="<html>(AllowShortLambdasOnASingleLine) Dependent on the value, <code>auto lambda []() { return 0; }</code> can be put on a single line.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AllowShortLambdasOnASingleLine: None|AllowShortLambdasOnASingleLine: Empty|AllowShortLambdasOnASingleLine: Inline|AllowShortLambdasOnASingleLine: All"
+ChoicesReadable="(None) Never merge lambdas into a single line.|(Empty) Only merge empty lambdas.|(Inline) Merge lambda into a single line if argument of a function.|(All) Merge all lambdas fitting on a single line."
+ValueDefault=3
 
 [AllowShortLoopsOnASingleLine]
 Category=1
@@ -193,6 +227,14 @@ EditorType=boolean
 TrueFalse="BraceWrapping:|BraceWrapping:"
 Value=1
 ValueDefault=1
+
+[ - AfterCaseLabel]
+Category=2
+Description="<html>Wrap case labels.<pre>false:                                true:<br/>switch (foo) {                vs.     switch (foo) {<br/>  case 1: {                             case1:<br/>    bar();                              {<br/>    break;                                bar();<br/>  }                                       break;<br/>  default: {                            }<br/>    plop();                             default:<br/>  }                                     {<br/>}                                         plop();<br/>                                        }<br/>                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterCaseLabel: true|    AfterCaseLabel: false"
+Value=0
+ValueDefault=0
 
 [ - AfterClass]
 Category=2
@@ -458,7 +500,7 @@ ValueDefault=0
 
 [FixNamespaceComments]
 Category=7
-Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a;                      }</pre></html>"
+Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a                       }</pre></html>"
 EditorType=boolean
 TrueFalse="FixNamespaceComments: true|FixNamespaceComments: false"
 Value=1
@@ -501,10 +543,11 @@ ValueDefault=0
 
 [IndentPPDirectives]
 Category=3
-Description="<html>The preprocessor directive indenting style to use.</html>"
-EditorType=boolean
-TrueFalse="IndentPPDirectives: AfterHash|IndentPPDirectives: None"
-Value=0
+Description="<html>(IndentPPDirectives) The preprocessor directive indenting style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="IndentPPDirectives: None|IndentPPDirectives: AfterHash|IndentPPDirectives: BeforeHash"
+ChoicesReadable="(None) Does not indent any directives.|(AfterHash) Indents directives after the hash.|(BeforeHash) Indents directives before the hash."
 ValueDefault=0
 
 [IndentWidth]
@@ -597,6 +640,15 @@ Enabled=false
 Choices="NamespaceIndentation: None|NamespaceIndentation: Inner|NamespaceIndentation: All"
 ChoicesReadable="(None) Don’t indent in namespaces.|(Inner) Indent only in inner namespaces (nested in other namespaces).|(All) Indent in all namespaces."
 ValueDefault=0
+
+[NamespaceMacros]
+Category=7
+Description="<html>A vector of macros which are used to open namespace blocks.<p>These are expected to be macros of the form:<pre>NAMESPACE(&lt;namespace-name>, ...) {<br/>  &lt;namespace-content><br/>}</pre><p>For example: TESTSUITE</html>"
+EditorType=string
+CallName="NamespaceMacros: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
 
 [ObjCBinPackProtocolList]
 Category=1
@@ -763,6 +815,14 @@ TrueFalse="SpaceAfterCStyleCast: true|SpaceAfterCStyleCast: false"
 Value=0
 ValueDefault=0
 
+[SpaceAfterLogicalNot]
+Category=5
+Description="<html>If <code>true</code>, a space is inserted after the logical not operator (<code>!</code>).<pre>true:                                  false:<br/>! someExpression();            vs.     !someExpression();</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceAfterLogicalNot: true|SpaceAfterLogicalNot: false"
+Value=0
+ValueDefault=0
+
 [SpaceAfterTemplateKeyword]
 Category=5
 Description="<html>If <code>true</code>, a space will be inserted after the ‘<code>template</code>’ keyword.<pre>true:                                  false:<br/>template &lt;int&gt; void foo();     vs.     template&lt;int&gt; void foo();</pre></html>"
@@ -808,8 +868,8 @@ Category=5
 Description="<html>(SpaceBeforeParens) Defines in which cases to put a space before opening parentheses.</html>"
 EditorType=multiple
 Enabled=false
-Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: Always"
-ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
+Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: NonEmptyParentheses|SpaceBeforeParens: Always"
+ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(NonEmptyParentheses) Put a space before opening parentheses only if the parentheses are not empty i.e. '()'|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
 ValueDefault=1
 
 [SpaceBeforeRangeBasedForLoopColon]
@@ -907,6 +967,15 @@ MaxVal=100
 MinVal=0
 Value=8
 ValueDefault=8
+
+[TypenameMacros]
+Category=7
+Description="<html>A vector of macros that should be interpreted as type declarations instead of as function calls.<p>These are expected to be macros of the form:<pre>STACK_OF(...)</pre><p>In the <code>.clang-format</code> configuration file, this can be configured like: <pre>TypenameMacros: ['STACK_OF', 'LIST']</pre><p>For example: OpenSSL STACK_OF, BSD LIST_ENTRY.</html>"
+EditorType=string
+CallName="TypenameMacros: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
 
 [UseTab]
 Category=3

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=http://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=7.0.0
+version=8.0.0
 
 [Language]
 Category=0
@@ -31,7 +31,7 @@ Description="<html>(BasedOnStyle) The style used for all options not specificall
 EditorType=multiple
 Enabled=false
 Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit"
-ChoicesReadable="(LLVM) LLVM coding standards - http://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - http://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - http://www.webkit.org/coding/coding-style.html"
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - http://www.chromium.org/developers/coding-style|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - http://www.webkit.org/coding/coding-style.html"
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -526,6 +526,15 @@ TrueFalse="IndentWrappedFunctionNames: true|IndentWrappedFunctionNames: false"
 Value=0
 ValueDefault=0
 
+[JavaImportGroups]
+Category=7
+Description="<html><p>A vector of prefixes ordered by the desired groups for Java imports.</p><p>Each group is separated by a newline. Static imports will also follow the same grouping convention above all non-static imports. One group’s prefix can be a subset of another - the longest prefix is always matched. Within a group, the imports are ordered lexicographically.</p><p>In the .clang-format configuration file, this can be configured like in the following yaml example.</p><pre>JavaImportGroups: ['com.example', 'com', 'org']</pre><p>This will result in imports being formatted as in the Java example below.</p><pre>import static com.example.function1;<br/><br/>import static com.test.function2;<br/><br/>import static org.example.function3;<br/><br/>import com.example.ClassA;<br/>import com.example.Test;<br/>import com.example.a.ClassB;<br/><br/>import com.test.ClassC;<br/><br/>import org.example.ClassD;</pre></html>"
+EditorType=string
+CallName="JavaImportGroups: "
+Enabled=false
+Value="[]"
+ValueDefault="[]"
+
 [JavaScriptQuotes]
 Category=7
 Description="<html>(JavaScriptQuotes) The quote style to use for JavaScript strings.</html>"
@@ -878,6 +887,15 @@ Enabled=false
 Choices="Standard: Cpp03|Standard: Cpp11|Standard: Auto"
 ChoicesReadable="(Cpp03) Use C++03-compatible syntax.|(Cpp11) Use features of C++11, C++14 and C++1z (e.g. A<A<int>> instead of A<A<int> >).|(Auto) Automatic detection based on the input."
 ValueDefault=2
+
+[StatementMacros]
+Category=7
+Description="<html>A vector of macros that should be interpreted as complete statements.<p>Typical macros are expressions, and require a semi-colon to be added; sometimes this is not the case, and this allows to make clang-format aware of such cases.<p>For example: <code>Q_UNUSED</code></html>"
+EditorType=string
+CallName="StatementMacros: "
+Enabled=false
+Value="['Q_UNUSED', 'QT_REQUIRE_VERSION']"
+ValueDefault="['Q_UNUSED', 'QT_REQUIRE_VERSION']"
 
 [TabWidth]
 Category=3

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -4,25 +4,25 @@ cfgFileParameterEnding=cr
 configFilename=.clang-format
 fileTypes=*.cpp|*.cxx|*.C|*.c|*.h|*.hpp|*.java|*.js|*.json|*.m|*.mm|*.M|*.proto|*.cs
 indenterFileName=clang-format
-indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#)
+indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#, Verilog)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=14.0.0
+version=15.0.0
 
 [Language]
 Category=0
 Description="<html>(Language) Language this format style is targeted at.</html>"
 EditorType=multiple
 Enabled=true
-Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: Json|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen|Language: CSharp"
-ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(Json) JSON|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen|(CSharp) C#"
+Choices="Language: Cpp|Language: Java|Language: JavaScript|Language: Json|Language: ObjC|Language: Proto|Language: TextProto|Language: TableGen|Language: CSharp|Language: Verilog"
+ChoicesReadable="(Cpp) C, C++|(Java) Java|(JavaScript) JavaScript|(Json) JSON|(ObjC) Objective C, Objective C++|(Proto) Protocol Buffers|(TextProto) Protocol Buffer messages in text format|(TableGen) TableGen|(CSharp) C#|(Verilog) Verilog and SystemVerilog"
 ValueDefault=0
 
 [BasedOnStyle]
@@ -56,7 +56,7 @@ ValueDefault=0
 
 [AlignArrayOfStructures]
 Category=4
-Description="<html>(AlignArrayOfStructures) if not <code>None</code>, when using initialization for an array of structs aligns the fields into columns.</html>"
+Description="<html>(AlignArrayOfStructures) if not <code>None</code>, when using initialization for an array of structs aligns the fields into columns.<p>NOTE: As of clang-format 15 this option only applied to arrays with equal number of columns per row.</p></html>"
 EditorType=multiple
 Enabled=false
 Choices="AlignArrayOfStructures: Left|AlignArrayOfStructures: Right|AlignArrayOfStructures: None"
@@ -65,16 +65,55 @@ ValueDefault=2
 
 [AlignConsecutiveAssignments]
 Category=4
-Description="<html>(AlignConsecutiveAssignments) Style of aligning consecutive assignments.<p><code>Consecutive</code> will result in formattings like:<pre>int a            = 1;<br/>int somelongname = 2;<br/>double c         = 3;</pre></html>"
-EditorType=multiple
-Enabled=false
-Choices="AlignConsecutiveAssignments: None|AlignConsecutiveAssignments: Consecutive|AlignConsecutiveAssignments: AcrossEmptyLines|AlignConsecutiveAssignments: AcrossComments|AlignConsecutiveAssignments: AcrossEmptyLinesAndComments"
-ChoicesReadable="(None) Do not align assignments on consecutive lines.|(Consecutive) Align assignments on consecutive lines.|(AcrossEmptyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments) Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments) Same as Consecutive, but also spans over lines only containing comments and empty lines."
+Description="<html>Style of aligning consecutive assignments.</html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveAssignments:|AlignConsecutiveAssignments:"
+Value=1
+ValueDefault=1
+
+[ - Enabled]
+Category=4
+Description="<html>Whether aligning is enabled.<pre>#define SHORT_NAME       42<br/>#define LONGER_NAME      0x007f<br/>#define EVEN_LONGER_NAME (2)<br/>#define foo(x)           (x * x)<br/>#define bar(y, z)        (y + z)<br/><br/>int a            = 1;<br/>int somelongname = 2;<br/>double c         = 3;<br/><br/>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;<br/><br/>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc;</pre></html>"
+EditorType=boolean
+TrueFalse="    Enabled: true|    Enabled: false"
+Value=0
+ValueDefault=0
+
+[ - AcrossEmptyLines]
+Category=4
+Description="<html>Whether to align across empty lines.<pre>true:<br/>int a            = 1;<br/>int somelongname = 2;<br/>double c         = 3;<br/><br/>int d            = 3;<br/><br/>false:<br/>int a            = 1;<br/>int somelongname = 2;<br/>double c         = 3;<br/><br/>int d = 3;</pre></html>"
+EditorType=boolean
+TrueFalse="    AcrossEmptyLines: true|    AcrossEmptyLines: false"
+Value=0
+ValueDefault=0
+
+[ - AcrossComments]
+Category=4
+Description="<html>Whether to align across comments.<pre>true:<br/>int d    = 3;<br/>/* A comment. */<br/>double e = 4;<br/><br/>false:<br/>int d = 3;<br/>/* A comment. */<br/>double e = 4;</pre></html>"
+EditorType=boolean
+TrueFalse="    AcrossComments: true|    AcrossComments: false"
+Value=0
+ValueDefault=0
+
+[ - AlignCompound]
+Category=4
+Description="<html>Only for <code>AlignConsecutiveAssignments</code>. Whether compound assignments like <code>+=</code> are aligned along with <code>=</code>.<pre>true:<br/>a   &amp;= 2;<br/>bbb  = 2;<br/><br/>false:<br/>a &amp;= 2;<br/>bbb = 2;</pre></html>"
+EditorType=boolean
+TrueFalse="    AlignCompound: true|    AlignCompound: false"
+Value=0
+ValueDefault=0
+
+[ - PadOperators]
+Category=4
+Description="<html>Only for <code>AlignConsecutiveAssignments</code>. Whether short assignment operators are left-padded to the same length as long ones in order to put all assignment operators to the right of the left hand side.<pre>true:<br/>a   &gt;&gt;= 2;<br/>bbb   = 2;<br/><br/>a     = 2;<br/>bbb &gt;&gt;= 2;<br/><br/>false:<br/>a &gt;&gt;= 2;<br/>bbb = 2;<br/><br/>a     = 2;<br/>bbb &gt;&gt;= 2;</pre></html>"
+EditorType=boolean
+TrueFalse="    PadOperators: true|    PadOperators: false"
+Value=0
 ValueDefault=0
 
 [AlignConsecutiveBitFields]
 Category=4
-Description="<html>(AlignConsecutiveBitFields) Style of aligning consecutive bit field.<p><code>Consecutive</code> will align the bitfield separators of consecutive lines. This will result in formattings like:<pre>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;</pre></html>"
+Description="<html>(AlignConsecutiveBitFields) Style of aligning consecutive bit fields.<p><code>Consecutive</code> will align the bitfield separators of consecutive lines. This will result in formattings like:<pre>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;</pre></html>"
 EditorType=multiple
 Enabled=false
 Choices="AlignConsecutiveBitFields: None|AlignConsecutiveBitFields: Consecutive|AlignConsecutiveBitFields: AcrossEmptyLines|AlignConsecutiveBitFields: AcrossComments|AlignConsecutiveBitFields: AcrossEmptyLinesAndComments"
@@ -409,7 +448,7 @@ ValueDefault=0
 
 [ - SplitEmptyFunction]
 Category=2
-Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>int f()   vs.   int f()<br/>{}              {<br/>                }</pre></html>"
+Description="<html>If <code>false</code>, empty function body can be put on a single line. This option is used only if the opening brace of the function has already been wrapped, i.e. the <code>AfterFunction</code> brace wrapping mode is set, and the function could/should not be put on a single line (as per <code>AllowShortFunctionsOnASingleLine</code> and constructor formatting options).<pre>false:          true:<br/>int f()   vs.   int f()<br/>{}              {<br/>                }</pre></html>"
 EditorType=boolean
 TrueFalse="    SplitEmptyFunction: true|    SplitEmptyFunction: false"
 Value=1
@@ -417,7 +456,7 @@ ValueDefault=1
 
 [ - SplitEmptyRecord]
 Category=2
-Description="<html>If <code>false</code>, empty record (e.g. <code>class</code>, <code>struct</code> or <code>union</code>) body can be put on a single line. This option is used only if the opening brace of the record has already been wrapped, i.e. the <code>AfterClass</code> (for classes) brace wrapping mode is set.<pre>class Foo   vs.  class Foo<br/>{}               {<br/>                 }</pre></html>"
+Description="<html>If <code>false</code>, empty record (e.g. <code>class</code>, <code>struct</code> or <code>union</code>) body can be put on a single line. This option is used only if the opening brace of the record has already been wrapped, i.e. the <code>AfterClass</code> (for classes) brace wrapping mode is set.<pre>false:           true:<br/>class Foo   vs.  class Foo<br/>{}               {<br/>                 }</pre></html>"
 EditorType=boolean
 TrueFalse="    SplitEmptyRecord: true|    SplitEmptyRecord: false"
 Value=1
@@ -425,7 +464,7 @@ ValueDefault=1
 
 [ - SplitEmptyNamespace]
 Category=2
-Description="<html>If <code>false</code>, empty namespace body can be put on a single line. This option is used only if the opening brace of the namespace has already been wrapped, i.e. the <code>AfterNamespace</code> brace wrapping mode is set.<pre>namespace Foo   vs.  namespace Foo<br/>{}                   {<br/>                     }</pre></html>"
+Description="<html>If <code>false</code>, empty namespace body can be put on a single line. This option is used only if the opening brace of the namespace has already been wrapped, i.e. the <code>AfterNamespace</code> brace wrapping mode is set.<pre>false:               true:<br/>namespace Foo   vs.  namespace Foo<br/>{}                   {<br/>                     }</pre></html>"
 EditorType=boolean
 TrueFalse="    SplitEmptyNamespace: true|    SplitEmptyNamespace: false"
 Value=1
@@ -459,11 +498,12 @@ ValueDefault=0
 
 [BreakBeforeConceptDeclarations]
 Category=1
-Description="<html>If true, concept will be placed on a new line.<pre>true:<br/> template&lt;typename T&gt;<br/> concept ...<br/><br/>false:<br/> template&lt;typename T&gt; concept ...</pre></html>"
-EditorType=boolean
-TrueFalse="BreakBeforeConceptDeclarations: true|BreakBeforeConceptDeclarations: false"
-Value=1
-ValueDefault=1
+Description="<html>(BreakBeforeConceptDeclarations) The concept declaration style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeConceptDeclarations: Never|BreakBeforeConceptDeclarations: Allowed|BreakBeforeConceptDeclarations: Always"
+ChoicesReadable="(Never) Keep the template declaration line together with `concept`.|(Allowed) Breaking between template declaration and `concept` is allowed. The actual behavior depends on the content and line breaking rules and penalities.|(Always) Always break before `concept`, putting it in the line after the template declaration."
+ValueDefault=2
 
 [BreakBeforeTernaryOperators]
 Category=1
@@ -710,13 +750,13 @@ Choices="IndentPPDirectives: None|IndentPPDirectives: AfterHash|IndentPPDirectiv
 ChoicesReadable="(None) Does not indent any directives.|(AfterHash) Indents directives after the hash.|(BeforeHash) Indents directives before the hash."
 ValueDefault=0
 
-[IndentRequires]
+[IndentRequiresClause]
 Category=3
-Description="<html>Indent the requires clause in a template<pre>true:<br/>template &lt;typename It&gt;<br/>  requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}<br/><br/>false:<br/>template &lt;typename It&gt;<br/>requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}</pre></html>"
+Description="<html>Indent the requires clause in a template. This only applies when <code>RequiresClausePosition</code> is <code>OwnLine</code>, or <code>WithFollowing</code>.<p>In clang-format 12, 13 and 14 it was named <code>IndentRequires</code>.</p><pre>true:<br/>template &lt;typename It&gt;<br/>  requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}<br/><br/>false:<br/>template &lt;typename It&gt;<br/>requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}</pre></html>"
 EditorType=boolean
-TrueFalse="IndentRequires: true|IndentRequires: false"
-Value=0
-ValueDefault=0
+TrueFalse="IndentRequiresClause: true|IndentRequiresClause: false"
+Value=1
+ValueDefault=1
 
 [IndentWidth]
 Category=3
@@ -734,6 +774,14 @@ Category=3
 Description="<html>Indent if a function definition or declaration is wrapped after the type.<pre>true:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>    LoooooooooooooooooooooooooooooooongFunctionDeclaration();<br/><br/>false:<br/>LoooooooooooooooooooooooooooooooooooooooongReturnType<br/>LoooooooooooooooooooooooooooooooongFunctionDeclaration();</pre></html>"
 EditorType=boolean
 TrueFalse="IndentWrappedFunctionNames: true|IndentWrappedFunctionNames: false"
+Value=0
+ValueDefault=0
+
+[InsertBraces]
+Category=7
+Description="<html>Insert braces after control statements (<code>if</code>, <code>else</code>, <code>for</code>, <code>do</code>, and <code>while</code>) in C++ unless the control statements are inside macro definitions or the braces would enclose preprocessor directives.<p><b>Warning</b><br/>Setting this option to <code>true</code> could lead to incorrect code formatting due to clang-format's lack of complete semantic information. As such, extra care should be taken to review code changes made by this option.</p><pre>false:                                    true:<br/><br/>if (isa&lt;FunctionDecl&gt;(D))        vs.      if (isa&lt;FunctionDecl&gt;(D)) {<br/>  handleFunctionDecl(D);                    handleFunctionDecl(D);<br/>else if (isa&lt;VarDecl&gt;(D))                 } else if (isa&lt;VarDecl&gt;(D)) {<br/>  handleVarDecl(D);                         handleVarDecl(D);<br/>else                                      } else {<br/>  return;                                   return;<br/>                                          }<br/><br/>while (i--)                      vs.      while (i--) {<br/>  for (auto *A : D.attrs())                 for (auto *A : D.attrs()) {<br/>    handleAttr(A);                            handleAttr(A);<br/>                                            }<br/>                                          }<br/><br/>do                               vs.      do {<br/>  --i;                                      --i;<br/>while (i);                                } while (i);</pre></html>"
+EditorType=boolean
+TrueFalse="InsertBraces: true|InsertBraces: false"
 Value=0
 ValueDefault=0
 
@@ -1062,6 +1110,15 @@ TrueFalse="RemoveBracesLLVM: true|RemoveBracesLLVM: false"
 Value=0
 ValueDefault=0
 
+[RequiresClausePosition]
+Category=1
+Description="<html>(RequiresClausePosition) </html>"
+EditorType=multiple
+Enabled=false
+Choices="RequiresClausePosition: OwnLine|RequiresClausePosition: WithPreceding|RequiresClausePosition: WithFollowing|RequiresClausePosition: SingleLine"
+ChoicesReadable="(OwnLine) Always put the `requires` clause on its own line.|(WithPreceding) Try to put the clause together with the preceding part of a declaration. For class templates: stick to the template declaration. For function templates: stick to the template declaration. For function declaration followed by a requires clause: stick to the parameter list.|(WithFollowing) Try to put the `requires` clause together with the class or function declaration.|(SingleLine) Try to put everything in the same line if possible. Otherwise normal line breaking rules take over."
+ValueDefault=0
+
 [SeparateDefinitionBlocks]
 Category=6
 Description="<html>(SeparateDefinitionBlocks) Specifies the use of empty lines to separate definition blocks, including classes, structs, enums, and functions.<pre>Never                  v.s.     Always<br/>#include &lt;cstring&gt;              #include &lt;cstring&gt;<br/>struct Foo {<br/>  int a, b, c;                  struct Foo {<br/>};                                int a, b, c;<br/>namespace Ns {                  };<br/>class Bar {<br/>public:                         namespace Ns {<br/>  struct Foobar {               class Bar {<br/>    int a;                      public:<br/>    int b;                        struct Foobar {<br/>  };                                int a;<br/>private:                            int b;<br/>  int t;                          };<br/>  int method1() {<br/>    // ...                      private:<br/>  }                               int t;<br/>  enum List {<br/>    ITEM1,                        int method1() {<br/>    ITEM2                           // ...<br/>  };                              }<br/>  template<typename T><br/>  int method2(T x) {              enum List {<br/>    // ...                          ITEM1,<br/>  }                                 ITEM2<br/>  int i, j, k;                    };<br/>  int method3(int par) {<br/>    // ...                        template<typename T><br/>  }                               int method2(T x) {<br/>};                                  // ...<br/>class C {};                       }<br/>}<br/>                                  int i, j, k;<br/><br/>                                  int method3(int par) {<br/>                                    // ...<br/>                                  }<br/>                                };<br/><br/>                                class C {};<br/>                                }</pre></html>"
@@ -1244,6 +1301,22 @@ Category=5
 Description="<html>If <code>true</code>, put a space between operator overloading and opening parentheses.<pre>true:                                  false:<br/>void operator++ (int a);        vs.    void operator++(int a);<br/>object.operator++ (10);                object.operator++(10);</pre></html>"
 EditorType=boolean
 TrueFalse="    AfterOverloadedOperator: true|    AfterOverloadedOperator: false"
+Value=0
+ValueDefault=0
+
+[ - AfterRequiresInClause]
+Category=5
+Description="<html>If <code>true</code>, put space between requires keyword in a requires clause and opening parentheses, if there is one.<pre>true:                                  false:<br/>template&lt;typename T&gt;            vs.    template&lt;typename T&gt;<br/>requires (A&lt;T&gt; &amp;&amp; B&lt;T&gt;)                requires(A&lt;T&gt; &amp;&amp; B&lt;T&gt;)<br/>...                                    ...</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterRequiresInClause: true|    AfterRequiresInClause: false"
+Value=0
+ValueDefault=0
+
+[ - AfterRequiresInExpression]
+Category=5
+Description="<html>If <code>true</code>, put space between requires keyword in a requires expression and opening parentheses.<pre>true:                                  false:<br/>template&lt;typename T&gt;            vs.    template&lt;typename T&gt;<br/>concept C = requires (T t) {           concept C = requires(T t) {<br/>              ...                                    ...<br/>            }                                      }</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterRequiresInExpression: true|    AfterRequiresInExpression: false"
 Value=0
 ValueDefault=0
 

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=11.0.0
+version=12.0.0
 
 [Language]
 Category=0
@@ -56,34 +56,38 @@ ValueDefault=0
 
 [AlignConsecutiveAssignments]
 Category=4
-Description="<html>Aligns consecutive assignments.<p>This will align the assignment operators of consecutive lines. This will result in formattings like<pre>int aaaa = 12;<br/>int b    = 23;<br/>int ccc  = 23;</pre></html>"
-EditorType=boolean
-TrueFalse="AlignConsecutiveAssignments: true|AlignConsecutiveAssignments: false"
-Value=0
+Description="<html>(AlignConsecutiveAssignments) Style of aligning consecutive assignments.<p><code>Consecutive</code> will result in formattings like:<pre>int a            = 1;<br/>int somelongname = 2;<br/>double c         = 3;</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignConsecutiveAssignments: None|AlignConsecutiveAssignments: Consecutive|AlignConsecutiveAssignments: AcrossEmptyLines|AlignConsecutiveAssignments: AcrossComments|AlignConsecutiveAssignments: AcrossEmptyLinesAndComments"
+ChoicesReadable="(None) Do not align assignments on consecutive lines.|(Consecutive) Align assignments on consecutive lines.|(AcrossEmptyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments) Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments) Same as Consecutive, but also spans over lines only containing comments and empty lines."
 ValueDefault=0
 
 [AlignConsecutiveBitFields]
 Category=4
-Description="<html>Aligns consecutive bitfield members.<p>This will align the bitfield separators of consecutive lines. This will result in formattings like<pre>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;</pre></html>"
-EditorType=boolean
-TrueFalse="AlignConsecutiveBitFields: true|AlignConsecutiveBitFields: false"
-Value=0
+Description="<html>(AlignConsecutiveBitFields) Style of aligning consecutive bit field.<p><code>Consecutive</code> will align the bitfield separators of consecutive lines. This will result in formattings like:<pre>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignConsecutiveBitFields: None|AlignConsecutiveBitFields: Consecutive|AlignConsecutiveBitFields: AcrossEmptyLines|AlignConsecutiveBitFields: AcrossComments|AlignConsecutiveBitFields: AcrossEmptyLinesAndComments"
+ChoicesReadable="(None) Do not align bit fields on consecutive lines.|(Consecutive) Align bit fields on consecutive lines.|(AcrossEmptyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments) Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments) Same as Consecutive, but also spans over lines only containing comments and empty lines."
 ValueDefault=0
 
 [AlignConsecutiveDeclarations]
 Category=4
-Description="<html>Aligns consecutive declarations.<p>This will align the declaration names of consecutive lines. This will result in formattings like<pre>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc = 23;</pre></html>"
-EditorType=boolean
-TrueFalse="AlignConsecutiveDeclarations: true|AlignConsecutiveDeclarations: false"
-Value=0
+Description="<html>(AlignConsecutiveDeclarations) Style of aligning consecutive declarations.<p><code>Consecutive</code> will align the declaration names of consecutive lines. This will result in formattings like:<pre>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc;</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignConsecutiveDeclarations: None|AlignConsecutiveDeclarations: Consecutive|AlignConsecutiveDeclarations: AcrossEmptyLines|AlignConsecutiveDeclarations: AcrossComments|AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments"
+ChoicesReadable="(None) Do not align bit declarations on consecutive lines.|(Consecutive) Align declarations on consecutive lines.|(AcrossEmptyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments)  Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments) Same as Consecutive, but also spans over lines only containing comments and empty lines."
 ValueDefault=0
 
 [AlignConsecutiveMacros]
 Category=4
-Description="<html>If <code>true</code>, aligns consecutive C/C++ preprocessor macros.<p>This will align the C/C++ preprocessor macros of consecutive lines. This will result in formattings like<pre>#define SHORT_NAME       42<br/>#define LONGER_NAME      0x007f<br/>#define EVEN_LONGER_NAME (2)<br/>#define foo(x)           (x * x)<br/>#define bar(y, z)        (y + z)</pre></html>"
-EditorType=boolean
-TrueFalse="AlignConsecutiveMacros: true|AlignConsecutiveMacros: false"
-Value=0
+Description="<html>(AlignConsecutiveMacros) Style of aligning consecutive macro definitions.<p><code>Consecutive</code> will result in formattings like:<pre>#define SHORT_NAME       42<br/>#define LONGER_NAME      0x007f<br/>#define EVEN_LONGER_NAME (2)<br/>#define foo(x)           (x * x)<br/>#define bar(y, z)        (y + z)</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignConsecutiveMacros: None|AlignConsecutiveMacros: Consecutive|AlignConsecutiveMacros: AcrossEmptyLines|AlignConsecutiveMacros: AcrossComments|AlignConsecutiveMacros: AcrossEmptyLinesAndComments"
+ChoicesReadable="(None) Do not align macro definitions on consecutive lines.|(Consecutive) Align macro definitions on consecutive lines.|(AcrossEmtpyLines) Same as Consecutive, but also spans over empty lines.|(AcrossComments)  Same as Consecutive, but also spans over lines only containing comments.|(AcrossEmptyLinesAndComments)  Same as Consecutive, but also spans over lines only containing comments and empty lines."
 ValueDefault=0
 
 [AlignEscapedNewlines]
@@ -222,6 +226,15 @@ Choices="AlwaysBreakTemplateDeclarations: No|AlwaysBreakTemplateDeclarations: Mu
 ChoicesReadable="(No) Do not force break before declaration. PenaltyBreakTemplateDeclaration is taken into account.|(MultiLine) Force break after template declaration only when the following declaration spans multiple lines.|(Yes) Always break after template declaration."
 ValueDefault=0
 
+[AttributeMacros]
+Category=7
+Description="<html>A vector of strings that should be interpreted as attributes/qualifiers instead of identifiers. This can be useful for language extensions or static analyzer annotations.<p>For example:<pre>x = (char *__capability)&y;<br/>int function(void) __ununsed;<br/>void only_writes_to_buffer(char *__output buffer);</pre><p>In the <code>.clang-format</code> configuration file, this can be configured like:<pre>AttributeMacros: ['__capability', '__output', '__ununsed']</pre></html>"
+EditorType=string
+CallName="AttributeMacros: "
+Enabled=false
+Value="['__capability']"
+ValueDefault="['__capability']"
+
 [BinPackArguments]
 Category=1
 Description="<html>If <code>false</code>, a function call’s arguments will either be all on the same line or will have one line each.<pre>true:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}<br/><br/>false:<br/>void f() {<br/>  f(aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaa,<br/>    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);<br/>}</pre></html>"
@@ -237,6 +250,24 @@ EditorType=boolean
 TrueFalse="BinPackParameters: true|BinPackParameters: false"
 Value=1
 ValueDefault=1
+
+[BitFieldColonSpacing]
+Category=5
+Description="<html>(BitFieldColonSpacing) The BitFieldColonSpacingStyle to use for bitfields.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BitFieldColonSpacing: Both|BitFieldColonSpacing: None|BitFieldColonSpacing: Before|BitFieldColonSpacing: After"
+ChoicesReadable="(Both) Add one space on each side of the ':'|(None) Add no space around the ':' (except when needed for AlignConsecutiveBitFields).|(Before) Add space before the ':' only|(After) Add space after the ':' only (space may be added before if needed for AlignConsecutiveBitFields)."
+ValueDefault=0
+
+[BreakBeforeBraces]
+Category=2
+Description="<html>(BreakBeforeBraces) The brace breaking style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: Mozilla|BreakBeforeBraces: Stroustrup|BreakBeforeBraces: Allman|BreakBeforeBraces: Whitesmiths|BreakBeforeBraces: GNU|BreakBeforeBraces: WebKit|BreakBeforeBraces: Custom"
+ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(Whitesmiths) Like Allman but always indent braces and line up code with braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
+ValueDefault=0
 
 [BraceWrapping]
 Category=2
@@ -417,6 +448,14 @@ Choices="BreakBeforeBraces: Attach|BreakBeforeBraces: Linux|BreakBeforeBraces: M
 ChoicesReadable="(Attach) Always attach braces to surrounding context.|(Linux) Like Attach, but break before braces on function, namespace and class definitions.|(Mozilla) Like Attach, but break before braces on enum, function, and record definitions.|(Stroustrup) Like Attach, but break before function definitions, catch, and else.|(Allman) Always break before braces.|(Whitesmiths) Like Allman but always indent braces and line up code with braces.|(GNU) Always break before braces and add an extra level of indentation to braces of control statements, not to those of class, function or other definitions.|(WebKit) Like Attach, but break before functions.|(Custom) Configure each individual brace in BraceWrapping."
 ValueDefault=0
 
+[BreakBeforeConceptDeclarations]
+Category=1
+Description="<html>If true, concept will be placed on a new line.<pre>true:<br/> template&lt;typename T&gt;<br/> concept ...<br/><br/>false:<br/> template&lt;typename T&gt; concept ...</pre></html>"
+EditorType=boolean
+TrueFalse="BreakBeforeConceptDeclarations: true|BreakBeforeConceptDeclarations: false"
+Value=1
+ValueDefault=1
+
 [BreakBeforeTernaryOperators]
 Category=1
 Description="<html>Ternary operators will be placed after line breaks.<pre>true:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription<br/>    ? firstValue<br/>    : SecondValueVeryVeryVeryVeryLong;<br/><br/>false:<br/>veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?<br/>    firstValue :<br/>    SecondValueVeryVeryVeryVeryLong;</pre></html>"
@@ -541,6 +580,15 @@ TrueFalse="DisableFormat: true|DisableFormat: false"
 Value=0
 ValueDefault=0
 
+[EmptyLineBeforeAccessModifier]
+Category=6
+Description="<html>(EmptyLineBeforeAccessModifier) Defines in which cases to put empty line before access modifiers.</html>"
+EditorType=multiple
+Enabled=false
+Choices="EmptyLineBeforeAccessModifier: Never|EmptyLineBeforeAccessModifier: Leave|EmptyLineBeforeAccessModifier: LogicalBlock|EmptyLineBeforeAccessModifier: Always"
+ChoicesReadable="(Never) Remove all empty lines before access modifiers.|(Leave) Keep existing empty lines before access modifiers.|(LogicalBlock) Add empty line only when access modifier starts a new logical block. Logical block is a group of one or more member fields or functions.|(Always) Always add empty line before access modifiers unless access modifier is at the start of struct or class definition."
+ValueDefault=2
+
 [FixNamespaceComments]
 Category=7
 Description="<html>If <code>true</code>, clang-format adds missing namespace end comments and fixes invalid existing ones.<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>} // namespace a                       }</pre></html>"
@@ -627,6 +675,14 @@ Choices="IndentPPDirectives: None|IndentPPDirectives: AfterHash|IndentPPDirectiv
 ChoicesReadable="(None) Does not indent any directives.|(AfterHash) Indents directives after the hash.|(BeforeHash) Indents directives before the hash."
 ValueDefault=0
 
+[IndentRequires]
+Category=3
+Description="<html>Indent the requires clause in a template<pre>true:<br/>template &lt;typename It&gt;<br/>  requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}<br/><br/>false:<br/>template &lt;typename It&gt;<br/>requires Iterator&lt;It&gt;<br/>void sort(It begin, It end) {<br/>  //....<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="IndentRequires: true|IndentRequires: false"
+Value=0
+ValueDefault=0
+
 [IndentWidth]
 Category=3
 Description="<html>The number of columns to use for indentation.<pre>IndentWidth: 3<br/><br/>void f() {<br/>   someFunction();<br/>   if (true, false) {<br/>      f();<br/>   }<br/>}</pre></html>"
@@ -657,7 +713,7 @@ ValueDefault=0
 
 [JavaImportGroups]
 Category=7
-Description="<html><p>A vector of prefixes ordered by the desired groups for Java imports.</p><p>Each group is separated by a newline. Static imports will also follow the same grouping convention above all non-static imports. One group’s prefix can be a subset of another - the longest prefix is always matched. Within a group, the imports are ordered lexicographically.</p><p>In the .clang-format configuration file, this can be configured like in the following yaml example.</p><pre>JavaImportGroups: ['com.example', 'com', 'org']</pre><p>This will result in imports being formatted as in the Java example below.</p><pre>import static com.example.function1;<br/><br/>import static com.test.function2;<br/><br/>import static org.example.function3;<br/><br/>import com.example.ClassA;<br/>import com.example.Test;<br/>import com.example.a.ClassB;<br/><br/>import com.test.ClassC;<br/><br/>import org.example.ClassD;</pre></html>"
+Description="<html><p>A vector of prefixes ordered by the desired groups for Java imports.</p><p>One group’s prefix can be a subset of another - the longest prefix is always matched. Within a group, the imports are ordered lexicographically. Static imports are grouped separately and follow the same group rules. By default, static imports are placed before non-static imports, but this behavior is changed by another option, SortJavaStaticImport.</p><p>In the .clang-format configuration file, this can be configured like in the following yaml example.</p><pre>JavaImportGroups: ['com.example', 'com', 'org']</pre><p>This will result in imports being formatted as in the Java example below.</p><pre>import static com.example.function1;<br/><br/>import static com.test.function2;<br/><br/>import static org.example.function3;<br/><br/>import com.example.ClassA;<br/>import com.example.Test;<br/>import com.example.a.ClassB;<br/><br/>import com.test.ClassC;<br/><br/>import org.example.ClassD;</pre></html>"
 EditorType=string
 CallName="JavaImportGroups: "
 Enabled=false
@@ -758,7 +814,7 @@ ValueDefault=2
 
 [ObjCBreakBeforeNestedBlockParam]
 Category=1
-Description="<html>Break parameters list into lines when there is nested block parameters in a fuction call.<pre>false:<br/> - (void)_aMethod<br/> {<br/>     [self.test1 t:self w:self callback:^(typeof(self) self, NSNumber<br/>     *u, NSNumber *v) {<br/>         u = c;<br/>     }]<br/> }<br/> true:<br/> - (void)_aMethod<br/> {<br/>    [self.test1 t:self<br/>                w:self<br/>         callback:^(typeof(self) self, NSNumber *u, NSNumber *v) {<br/>             u = c;<br/>         }]<br/> }</pre></html>"
+Description="<html>Break parameters list into lines when there is nested block parameters in a function call.<pre>false:<br/> - (void)_aMethod<br/> {<br/>     [self.test1 t:self w:self callback:^(typeof(self) self, NSNumber<br/>     *u, NSNumber *v) {<br/>         u = c;<br/>     }]<br/> }<br/> true:<br/> - (void)_aMethod<br/> {<br/>    [self.test1 t:self<br/>                w:self<br/>         callback:^(typeof(self) self, NSNumber *u, NSNumber *v) {<br/>             u = c;<br/>         }]<br/> }</pre></html>"
 EditorType=boolean
 TrueFalse="ObjCBreakBeforeNestedBlockParam: true|ObjCBreakBeforeNestedBlockParam: false"
 Value=1
@@ -857,6 +913,17 @@ MinVal=0
 Value=0
 ValueDefault=0
 
+[PenaltyIndentedWhitespace]
+Category=1
+Description="<html>Penalty for each character of whitespace indentation (counted relative to leading non-whitespace column).</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyIndentedWhitespace: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
 [PenaltyReturnTypeOnItsOwnLine]
 Category=1
 Description="<html>Penalty for putting the return type of a function onto its own line.</html>"
@@ -893,6 +960,15 @@ TrueFalse="SortIncludes: true|SortIncludes: false"
 Value=1
 ValueDefault=1
 
+[SortJavaStaticImport]
+Category=7
+Description="<html>(SortJavaStaticImport) When sorting Java imports, by default static imports are placed before non-static imports. If JavaStaticImportAfterImport is After, static imports are placed after non-static imports.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SortJavaStaticImport: Before|SortJavaStaticImport: After"
+ChoicesReadable="(Before) Static imports are placed before non-static imports.|(After) Static imports are placed after non-static imports."
+ValueDefault=0
+
 [SortUsingDeclarations]
 Category=7
 Descriptions="<html>If <code>true</code>, clang-format will sort <code>using</code> declarations.<p>The order of <code>using</code> declarations is defined as follows: Split the strings by “::” and discard any initial empty strings. The last element of each list is a non-namespace name; all others are namespace names. Sort the lists of names lexicographically, where the sort order of individual names is that all non-namespace names come before all namespace names, and within those groups, names are in case-insensitive lexicographic order.<pre>false:                                 true:<br/>using std::cout;               vs.     using std::cin;<br/>using std::cin;                        using std::cout;</pre></html>"
@@ -925,6 +1001,15 @@ TrueFalse="SpaceAfterTemplateKeyword: true|SpaceAfterTemplateKeyword: false"
 Value=1
 ValueDefault=1
 
+[SpaceAroundPointerQualifiers]
+Category=5
+Description="<html>(SpaceAroundPointerQualifiers) Defines in which cases to put a space before or after pointer qualifiers</html>"
+EditorType=multiple
+Enabled=false
+Choices="SpaceAroundPointerQualifiers: Default|SpaceAroundPointerQualifiers: Before|SpaceAroundPointerQualifiers: After|SpaceAroundPointerQualifiers: Both"
+ChoicesReadable="(Default) Don't ensure spaces around pointer qualifiers and use PointerAlignment instead.|(Before) Ensure that there is a space before pointer qualifiers.|(After) Ensure that there is a space after pointer qualifiers.|(Both) Ensure that there is a space both before and after pointer qualifiers."
+ValueDefault=0
+
 [SpaceBeforeAssignmentOperators]
 Category=5
 Description="<html>If <code>false</code>, spaces will be removed before assignment operators.<pre>true:                                  false:<br/>int a = 5;                     vs.     int a= 5;<br/>a += 42;                               a+= 42;</pre></html>"
@@ -932,6 +1017,14 @@ EditorType=boolean
 TrueFalse="SpaceBeforeAssignmentOperators: true|SpaceBeforeAssignmentOperators: false"
 Value=1
 ValueDefault=1
+
+[SpaceBeforeCaseColon]
+Category=5
+Description="<html>If <code>false</code>, spaces will be removed before case colon.<pre>true:                                   false<br/>switch (x) {                    vs.     switch (x) {<br/>  case 1 : break;                         case 1: break;<br/>}                                       }</pre></html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeCaseColon: true|SpaceBeforeCaseColon: false"
+Value=0
+ValueDefault=0
 
 [SpaceBeforeCpp11BracedList]
 Category=5
@@ -1065,6 +1158,15 @@ Enabled=false
 Choices="Standard: c++03|Standard: c++11|Standard: c++14|Standard: c++17|Standard: c++20|Standard: Latest|Standard: Auto"
 ChoicesReadable="(c++03) Parse and format as C++03. 'Cpp03' is a deprecated alias for 'c++03'.|(c++11) Parse and format as C++11.|(c++14) Parse and format as C++14.|(c++17) Parse and format as C++17.|(c++20) Parse and format as C++20.|(Latest) Parse and format using the latest supported language version. 'Cpp11' is a deprecated alias for 'Latest'.|(Auto) Automatic detection based on the input."
 ValueDefault=6
+
+[StatementAttributeLikeMacros]
+Category=4
+Description="<html>Macros which are ignored in front of a statement, as if they were an attribute. So that they are not parsed as identifier, for example for Qts emit.<pre>AlignConsecutiveDeclarations: true<br/>StatementAttributeLikeMacros: []<br/>unsigned char data = 'x';<br/>emit          signal(data); // This is parsed as variable declaration.<br/><br/>AlignConsecutiveDeclarations: true<br/>StatementAttributeLikeMacros: [emit]<br/>unsigned char data = 'x';<br/>emit signal(data); // Now it's fine again.</pre></html>"
+EditorType=string
+CallName="StatementAttributeLikeMacros: "
+Enabled=false
+Value="['Q_EMIT']"
+ValueDefault="['Q_EMIT']"
 
 [StatementMacros]
 Category=7

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=9.0.0
+version=11.0.0
 
 [Language]
 Category=0
@@ -30,8 +30,8 @@ Category=0
 Description="<html>(BasedOnStyle) The style used for all options not specifically set in the configuration.</html>"
 EditorType=multiple
 Enabled=false
-Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft"
-ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017"
+Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft|BasedOnStyle: GNU"
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017|(GNU) GNU coding standards - https://www.gnu.org/prep/standards/standards.html"
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -62,6 +62,14 @@ TrueFalse="AlignConsecutiveAssignments: true|AlignConsecutiveAssignments: false"
 Value=0
 ValueDefault=0
 
+[AlignConsecutiveBitFields]
+Category=4
+Description="<html>Aligns consecutive bitfield members.<p>This will align the bitfield separators of consecutive lines. This will result in formattings like<pre>int aaaa : 1;<br/>int b    : 12;<br/>int ccc  : 8;</pre></html>"
+EditorType=boolean
+TrueFalse="AlignConsecutiveBitFields: true|AlignConsecutiveBitFields: false"
+Value=0
+ValueDefault=0
+
 [AlignConsecutiveDeclarations]
 Category=4
 Description="<html>Aligns consecutive declarations.<p>This will align the declaration names of consecutive lines. This will result in formattings like<pre>int         aaaa = 12;<br/>float       b = 23;<br/>std::string ccc = 23;</pre></html>"
@@ -89,10 +97,11 @@ ValueDefault=2
 
 [AlignOperands]
 Category=4
-Description="<html>Horizontally align operands of binary and ternary expressions.<p>Specifically, this aligns operands of a single expression that needs to be split over multiple lines, e.g.:<pre>int aaa = bbbbbbbbbbbbbbb +<br/>          ccccccccccccccc;</pre></html>"
-EditorType=boolean
-TrueFalse="AlignOperands: true|AlignOperands: false"
-Value=1
+Description="<html>(AlignOperands) Horizontally align operands of binary and ternary expressions.</html>"
+EditorType=multiple
+Enabled=false
+Choices="AlignOperands: DontAlign|AlignOperands: Align|AlignOperands: AlignAfterOperator"
+ChoicesReadable="(DontAlign) Do not align operands of binary and ternary expressions. The wrapped lines are indented ContinuationIndentWidth spaces from the start of the line.|(Align) Align operands of a single expression that needs to be split over multiple lines. When BreakBeforeBinaryOperators is set, the wrapped operator is aligned with the operand on the first line.|(AlignAfterOperator) Similar to Align, except when BreakBeforeBinaryOperators is set, the operator is un-indented so that the wrapped operand is aligned with the operand on the first line."
 ValueDefault=1
 
 [AlignTrailingComments]
@@ -143,6 +152,14 @@ EditorType=boolean
 TrueFalse="AllowShortCaseLabelsOnASingleLine: true|AllowShortCaseLabelsOnASingleLine: false"
 Value=0
 ValueDefault=0
+
+[AllowShortEnumsOnASingleLine]
+Category=1
+Description="<html>Allow short enums on a single line.<pre>true:<br/>enum { A, B } myEnum;<br/><br/>false:<br/>enum<br/>{<br/>  A,<br/>  B<br/>} myEnum;</pre></html>"
+EditorType=boolean
+TrueFalse="AllowShortEnumsOnASingleLine: true|AllowShortEnumsOnASingleLine: false"
+Value=1
+ValueDefault=1
 
 [AllowShortFunctionsOnASingleLine]
 Category=1
@@ -323,6 +340,22 @@ Category=2
 Description="<html>Wrap before <code>else</code>.<pre>true:<br/>if (foo()) {<br/>}<br/>else {<br/>}<br/><br/>false:<br/>if (foo()) {<br/>} else {<br/>}</pre></html>"
 EditorType=boolean
 TrueFalse="    BeforeElse: true|    BeforeElse: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeLambdaBody]
+Category=2
+Description="<html>Wrap lambda block.<pre>true:<br/>connect(<br/>  []()<br/>  {<br/>    foo();<br/>    bar();<br/>  });<br/><br/>false:<br/>connect([]() {<br/>  foo();<br/>  bar();<br/>});</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeLambdaBody: true|    BeforeLambdaBody: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeWhile]
+Category=2
+Description="<html>Wrap before <code>while</code>.<pre>true:<br/>do {<br/>  foo();<br/>}<br/>while (1);<br/><br/>false:<br/>do {<br/>  foo();<br/>} while (1);</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeWhile: true|    BeforeWhile: false"
 Value=0
 ValueDefault=0
 
@@ -552,12 +585,29 @@ Enabled=false
 Value="''"
 ValueDefault="''"
 
+[IndentCaseBlocks]
+Category=3
+Description="<html>Indent case label blocks one level from the case label.<p>When <code>false</code>, the block following the case label uses the same indentation level as for the case label, treating the case label the same as an if-statement. When <code>true</code>, the block gets indented as a scope block.<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1: {                              case 1:<br/>  bar();                                 {<br/>} break;                                   bar();<br/>default: {                               }<br/>  plop();                                break;<br/>}                                      default:<br/>}                                        {<br/>                                           plop();<br/>                                         }<br/>                                       }</pre></html>"
+EditorType=boolean
+TrueFalse="IndentCaseBlocks: true|IndentCaseBlocks: false"
+Value=0
+ValueDefault=0
+
 [IndentCaseLabels]
 Category=3
-Description="<html>Indent <code>case</code> labels one level from the <code>switch</code> statement.<p>When <code>false</code>, use the same indentation level as for the <code>switch</code> statement. Switch statement body is always indented one level more than <code>case</code> labels.<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1:                                  case 1:<br/>  bar();                                   bar();<br/>  break;                                   break;<br/>default:                                 default:<br/>  plop();                                  plop();<br/>}                                      }</pre></html>"
+Description="<html>Indent <code>case</code> labels one level from the <code>switch</code> statement.<p>When <code>false</code>, use the same indentation level as for the <code>switch</code> statement. Switch statement body is always indented one level more than <code>case</code> labels (except the first block following the case label, which itself indents the code - unless IndentCaseBlocks is enabled).<pre>false:                                 true:<br/>switch (fool) {                vs.     switch (fool) {<br/>case 1:                                  case 1:<br/>  bar();                                   bar();<br/>  break;                                   break;<br/>default:                                 default:<br/>  plop();                                  plop();<br/>}                                      }</pre></html>"
 EditorType=boolean
 TrueFalse="IndentCaseLabels: true|IndentCaseLabels: false"
 Value=0
+ValueDefault=0
+
+[IndentExternBlock]
+Category=3
+Description="<html>(IndentExternBlock) The type of indenting of extern blocks.</html>"
+EditorType=multiple
+Enabled=false
+Choices="IndentExternBlock: AfterExternBlock|IndentExternBlock: NoIndent|IndentExternBlock: Indent"
+ChoicesReadable="(AfterExternBlock) Backwards compatible with AfterExternBlock’s indenting.|(NoIndent) Does not indent extern blocks.|(Indent) Indents extern blocks."
 ValueDefault=0
 
 [IndentGotoLabels]
@@ -594,6 +644,15 @@ Description="<html>Indent if a function definition or declaration is wrapped aft
 EditorType=boolean
 TrueFalse="IndentWrappedFunctionNames: true|IndentWrappedFunctionNames: false"
 Value=0
+ValueDefault=0
+
+[InsertTrailingCommas]
+Category=7
+Description="<html>(InsertTrailingCommas) If set to <code>Wrapped</code> will insert trailing commas in container literals (arrays and objects) that wrap across multiple lines. It is currently only available for JavaScript and disabled by default. Cannot be used together with <code>BinPackArguments</code> as inserting the comma disables bin-packing.<pre>Wrapped:<br/>const someArray = [<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>//                        ^ inserted<br/>]</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="InsertTrailingCommas: None|InsertTrailingCommas: Wrapped"
+ChoicesReadable="(None) Do not insert trailing commas.|(Wrapped) Insert trailing commas in container literals that were wrapped over multiple lines."
 ValueDefault=0
 
 [JavaImportGroups]
@@ -696,6 +755,14 @@ MaxVal=1000
 MinVal=0
 Value=2
 ValueDefault=2
+
+[ObjCBreakBeforeNestedBlockParam]
+Category=1
+Description="<html>Break parameters list into lines when there is nested block parameters in a fuction call.<pre>false:<br/> - (void)_aMethod<br/> {<br/>     [self.test1 t:self w:self callback:^(typeof(self) self, NSNumber<br/>     *u, NSNumber *v) {<br/>         u = c;<br/>     }]<br/> }<br/> true:<br/> - (void)_aMethod<br/> {<br/>    [self.test1 t:self<br/>                w:self<br/>         callback:^(typeof(self) self, NSNumber *u, NSNumber *v) {<br/>             u = c;<br/>         }]<br/> }</pre></html>"
+EditorType=boolean
+TrueFalse="ObjCBreakBeforeNestedBlockParam: true|ObjCBreakBeforeNestedBlockParam: false"
+Value=1
+ValueDefault=1
 
 [ObjCSpaceAfterProperty]
 Category=5
@@ -895,8 +962,8 @@ Category=5
 Description="<html>(SpaceBeforeParens) Defines in which cases to put a space before opening parentheses.</html>"
 EditorType=multiple
 Enabled=false
-Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: NonEmptyParentheses|SpaceBeforeParens: Always"
-ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(NonEmptyParentheses) Put a space before opening parentheses only if the parentheses are not empty i.e. '()'|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
+Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: ControlStatementsExceptForEachMacros|SpaceBeforeParens: NonEmptyParentheses|SpaceBeforeParens: Always"
+ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(ControlStatementsExceptForEachMacros) Same as ControlStatements except this option doesn’t apply to ForEach macros. This is useful in projects where ForEach macros are treated as function calls instead of control statements.|(NonEmptyParentheses) Put a space before opening parentheses only if the parentheses are not empty i.e. '()'|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
 ValueDefault=1
 
 [SpaceBeforeRangeBasedForLoopColon]
@@ -960,7 +1027,7 @@ ValueDefault=0
 
 [SpacesInConditionalStatement]
 Category=5
-Description="<html>If <code>true</code>, spaces will be inserted around if/for/while (and similar) conditions.</html>"
+Description="<html>If <code>true</code>, spaces will be inserted around if/for/switch/while conditions.<pre>true:                                  false:<br/>if ( a )  { ... }              vs.     if (a) { ... }<br/>while ( i < 5 )  { ... }               while (i < 5) { ... }</pre></html>"
 EditorType=boolean
 TrueFalse="SpacesInConditionalStatement: true|SpacesInConditionalStatement: false"
 Value=0
@@ -1042,5 +1109,14 @@ Description="<html>(UseTab) The way to use tab characters in the resulting file.
 EditorType=multiple
 Enabled=false
 Choices="UseTab: Never|UseTab: ForIndentation|UseTab: ForContinuationAndIndentation|UseTab: Always"
-ChoicesReadable="(Never) Never use tab.|(ForIndentation) Use tabs only for indentation.|(ForContinuationAndIndentation) Use tabs only for line continuation and indentation.|(Always) Use tabs whenever we need to fill whitespace that spans at least from one tab stop to the next one."
+ChoicesReadable="(Never) Never use tab.|(ForIndentation) Use tabs only for indentation.|(ForContinuationAndIndentation) Fill all leading whitespace with tabs, and use spaces for alignment that appears within a line (e.g. consecutive assignments and declarations).|(AlignWithSpaces) Use tabs for line continuation and indentation, and spaces for alignment.|(Always) Use tabs whenever we need to fill whitespace that spans at least from one tab stop to the next one."
 ValueDefault=0
+
+[WhitespaceSensitiveMacros]
+Category=7
+Description="<html>A vector of macros which are whitespace-sensitive and should not be touched.<p>These are expected to be macros of the form:<pre>STRINGIZE(...)</pre>In the .clang-format configuration file, this can be configured like:<pre>WhitespaceSensitiveMacros: ['STRINGIZE', 'PP_STRINGIZE']</pre>For example: BOOST_PP_STRINGIZE.</html>"
+EditorType=string
+CallName="WhitespaceSensitiveMacros: "
+Enabled=false
+Value="['STRINGIZE', 'PP_STRINGIZE', 'BOOST_PP_STRINGIZE']"
+ValueDefault="['STRINGIZE', 'PP_STRINGIZE', 'BOOST_PP_STRINGIZE']"

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=13.0.0
+version=14.0.0
 
 [Language]
 Category=0
@@ -31,7 +31,7 @@ Description="<html>(BasedOnStyle) The style used for all options not specificall
 EditorType=multiple
 Enabled=false
 Choices="BasedOnStyle: LLVM|BasedOnStyle: Google|BasedOnStyle: Chromium|BasedOnStyle: Mozilla|BasedOnStyle: WebKit|BasedOnStyle: Microsoft|BasedOnStyle: GNU|BasedOnStyle: InheritParentConfig"
-ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/master/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017|(GNU) GNU coding standards - https://www.gnu.org/prep/standards/standards.html|(InheritParentConfig) Not a real style, but allows to use the .clang-format file from the parent directory (or its parent if there is none)."
+ChoicesReadable="(LLVM) LLVM coding standards - https://llvm.org/docs/CodingStandards.html|(Google) Google’s C++ style guide - https://google.github.io/styleguide/cppguide.html|(Chromium) Chromium’s style guide - https://chromium.googlesource.com/chromium/src/+/refs/heades/main/styleguide/styleguide.md|(Mozilla) Mozilla’s style guide - https://firefox-source-docs.mozilla.org/code-quality/coding-style/index.html|(WebKit) WebKit’s style guide - https://www.webkit.org/coding/coding-style.html|(Microsoft) Microsoft’s style guide - https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference|(GNU) GNU coding standards - https://www.gnu.org/prep/standards/standards.html|(InheritParentConfig) Not a real style, but allows to use the .clang-format file from the parent directory (or its parent if there is none)."
 ValueDefault=0
 
 [AccessModifierOffset]
@@ -50,8 +50,8 @@ Category=4
 Description="<html>(AlignAfterOpenBracket) Horizontally aligns arguments after an open bracket.<p>This applies to round brackets (parentheses), angle brackets and square brackets.</html>"
 EditorType=multiple
 Enabled=false
-Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak"
-ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line."
+Choices="AlignAfterOpenBracket: Align|AlignAfterOpenBracket: DontAlign|AlignAfterOpenBracket: AlwaysBreak|AlignAfterOpenBracket: BlockIndent"
+ChoicesReadable="(Align) Align parameters on the open bracket.|(DontAlign) Don’t align, instead use ContinuationIndentWidth.|(AlwaysBreak) Always break after an open bracket if the parameters don’t fit on a single line.|(BlockIndent) Always break after an open bracket, if the parameters don't fit on a single line. Closing brackets will be placed on a new line. Note: This currently only applies to parentheses."
 ValueDefault=0
 
 [AlignArrayOfStructures]
@@ -135,7 +135,7 @@ ValueDefault=1
 
 [AllowAllConstructorInitializersOnNextLine]
 Category=1
-Description="<html>If a constructor definition with a member initializer list doesn’t fit on a single line, allow putting all member initializers onto the next line, if <code>ConstructorInitializerAllOnOneLineOrOnePerLine</code> is true. Note that this parameter has no effect if <code>ConstructorInitializerAllOnOneLineOrOnePerLine</code> is false.<pre>true:<br/>MyClass::MyClass() :<br/>    member0(0), member1(2) {}<br/><br/>false:<br/>MyClass::MyClass() :<br/>    member0(0),<br/>    member1(2) {}</pre></html>"
+Description="<html>This option is <b>deprecated</b>. See <code>NextLine</code> of <code>PackConstructorInitializers</code>.</html>"
 EditorType=boolean
 TrueFalse="AllowAllConstructorInitializersOnNextLine: true|AllowAllConstructorInitializersOnNextLine: false"
 Value=1
@@ -168,7 +168,7 @@ ValueDefault=0
 
 [AllowShortEnumsOnASingleLine]
 Category=1
-Description="<html>Allow short enums on a single line.<pre>true:<br/>enum { A, B } myEnum;<br/><br/>false:<br/>enum<br/>{<br/>  A,<br/>  B<br/>} myEnum;</pre></html>"
+Description="<html>Allow short enums on a single line.<pre>true:<br/>enum { A, B } myEnum;<br/><br/>false:<br/>enum {<br/>  A,<br/>  B<br/>} myEnum;</pre></html>"
 EditorType=boolean
 TrueFalse="AllowShortEnumsOnASingleLine: true|AllowShortEnumsOnASingleLine: false"
 Value=1
@@ -475,7 +475,7 @@ ValueDefault=0
 
 [BreakConstructorInitializers]
 Category=1
-Description="<html>(BreakConstructorInitializers) The constructor initializers style to use.</html>"
+Description="<html>(BreakConstructorInitializers) The break constructor initializers style to use.</html>"
 EditorType=multiple
 Enabled=false
 Choices="BreakConstructorInitializers: BeforeColon|BreakConstructorInitializers: BeforeComma|BreakConstructorInitializers: AfterColon"
@@ -529,7 +529,7 @@ ValueDefault=0
 
 [ConstructorInitializerAllOnOneLineOrOnePerLine]
 Category=1
-Description="<html>If the constructor initializers don’t fit on a line, put each initializer on its own line.<pre>true:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}<br/><br/>false:<br/>SomeClass::Constructor()<br/>    : aaaaaaaa(aaaaaaaa), aaaaaaaa(aaaaaaaa),<br/>      aaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaa) {<br/>  return 0;<br/>}</pre></html>"
+Description="<html>This option is <b>deprecated</b>. See <code>CurrentLine</code> of <code>PackConstructorInitializers</code>.</html>"
 EditorType=boolean
 TrueFalse="ConstructorInitializerAllOnOneLineOrOnePerLine: true|ConstructorInitializerAllOnOneLineOrOnePerLine: false"
 Value=0
@@ -880,6 +880,15 @@ TrueFalse="ObjCSpaceBeforeProtocolList: true|ObjCSpaceBeforeProtocolList: false"
 Value=0
 ValueDefault=0
 
+[PackConstructorInitializers]
+Category=1
+Description="<html>(PackConstructorInitializers) The pack constructor initializers style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="PackConstructorInitializers: Never|PackConstructorInitializers: BinPack|PackConstructorInitializers: CurrentLine|PackConstructorInitializers: NextLine"
+ChoicesReadable="(Never) Always put each constructor initializer on its own line.|(BinPack) Bin-pack constructor initializers.|(CurrentLine) Put all constructor initializers on the current line if they fit. Otherwise, put each one on its own line.|(NextLine) Same as CurrentLine except that if all constructor initializers do not fit on the current line, try to fit them on the next line."
+ValueDefault=1
+
 [PenaltyBreakAssignment]
 Category=1
 Description="<html>The penalty for breaking around an assignment operator.</html>"
@@ -919,6 +928,17 @@ Description="<html>The penalty for breaking before the first <code>&lt;&lt;</cod
 EditorType=numeric
 Enabled=false
 CallName="PenaltyBreakFirstLessLess: "
+MaxVal=10000000
+MinVal=0
+Value=0
+ValueDefault=0
+
+[PenaltyBreakOpenParenthesis]
+Category=1
+Description="<html>The penalty for breaking after <code>(</code>.</html>"
+EditorType=numeric
+Enabled=false
+CallName="PenaltyBreakOpenParenthesis: "
 MaxVal=10000000
 MinVal=0
 Value=0
@@ -999,6 +1019,24 @@ MinVal=-1
 Value=-1
 ValueDefault=-1
 
+[QualifierAlignment]
+Category=7
+Description="<html>(QualifierAlignment) Different ways to arrange specifiers and qualifiers (e.g. const/volatile).<p>WARNING: Setting <code>QualifierAlignment</code> to something other than <code>Leave</code>, COULD lead to incorrect code formatting due to incorrect decisions made due to clang-formats lack of complete semantic information. As such extra care should be taken to review code changes made by the use of this option.</p></html>"
+EditorType=multiple
+Enabled=false
+Choices="QualifierAlignment: Leave|QualifierAlignment: Left|QualifierAlignment: Right|QualifierAlignment: Custom"
+ChoicesReadable="(Leave) Don't change specifiers/qualifiers to either Left or Right alignment.|(Left) Change specifiers/qualifiers to be left-aligned.|(Right) Change specifiers/qualifiers to be right-aligned.|(Custom) Change specifiers/qualifiers to be aligned based on QualifierOrder."
+ValueDefault=0
+
+[QualifierOrder]
+Category=7
+Description="<html>The order in which the qualifiers appear.<p>Order is an array that can contain any of the following:<ul><li>const</li><li>inline</li><li>static</li><li>constexpr</li><li>volatile</li><li>restrict</li><li>type</li></ul>Note: it MUST contain 'type'.<br/>Items to the left of 'type' will be placed to the left of the type and aligned in the order supplied. Items to the right of 'type' will be placed to the right of the type and aligned in the order supplied.</html>"
+EditorType=string
+CallName="QualifierOrder: "
+Enabled=false
+Value="['type']"
+ValueDefault="['type']"
+
 [ReferenceAlignment]
 Category=4
 Description="<html>(ReferenceAlignment) Reference alignment style (overrides <code>PointerAlignment</code> for references).</html>"
@@ -1015,6 +1053,23 @@ EditorType=boolean
 TrueFalse="ReflowComments: true|ReflowComments: false"
 Value=1
 ValueDefault=1
+
+[RemoveBracesLLVM]
+Category=7
+Description="<html>Remove optional braces of control statements (<code>if</code>, <code>else</code>, <code>for</code>, and <code>while</code>) in C++ according to the LLVM coding style.<p><b>Warning</b><br/>This option will be renamed and expanded to support other styles.</p><p><b>Warning</b><br/>Setting this option to <code>true</code> could lead to incorrect code formatting due to clang-format's lack of complete semantic information. As such, extra care should be taken to review code changes made by this option.</p><pre>false:                                     true:<br/><br/>if (isa&lt;FunctionDecl&gt;(D)) {        vs.     if (isa&lt;FunctionDecl&gt;(D))<br/>  handleFunctionDecl(D);                     handleFunctionDecl(D);<br/>} else if (isa&lt;VarDecl&gt;(D)) {              else if (isa&lt;VarDecl&gt;(D))<br/>  handleVarDecl(D);                          handleVarDecl(D);<br/>}<br/><br/>if (isa&lt;VarDecl&gt;(D)) {             vs.     if (isa&lt;VarDecl&gt;(D)) {<br/>  for (auto *A : D.attrs()) {                for (auto *A : D.attrs())<br/>    if (shouldProcessAttr(A)) {                if (shouldProcessAttr(A))<br/>      handleAttr(A);                             handleAttr(A);<br/>    }                                      }<br/>  }<br/>}<br/><br/>if (isa&lt;FunctionDecl&gt;(D)) {        vs.     if (isa&lt;FunctionDecl&gt;(D))<br/>  for (auto *A : D.attrs()) {                for (auto *A : D.attrs())<br/>    handleAttr(A);                             handleAttr(A);<br/>  }<br/>}<br/><br/>if (auto *D = (T)(D)) {            vs.     if (auto *D = (T)(D)) {<br/>  if (shouldProcess(D)) {                    if (shouldProcess(D))<br/>    handleVarDecl(D);                          handleVarDecl(D);<br/>  } else {                                   else<br/>    markAsIgnored(D);                          markAsIgnored(D);<br/>  }                                        }<br/>}<br/><br/>if (a) {                           vs.     if (a)<br/>  b();                                       b();<br/>} else {                                   else if (c)<br/>  if (c) {                                   d();<br/>    d();                                   else<br/>  } else {                                   e();<br/>    e();<br/>  }<br/>}</pre></html>"
+EditorType=boolean
+TrueFalse="RemoveBracesLLVM: true|RemoveBracesLLVM: false"
+Value=0
+ValueDefault=0
+
+[SeparateDefinitionBlocks]
+Category=6
+Description="<html>(SeparateDefinitionBlocks) Specifies the use of empty lines to separate definition blocks, including classes, structs, enums, and functions.<pre>Never                  v.s.     Always<br/>#include &lt;cstring&gt;              #include &lt;cstring&gt;<br/>struct Foo {<br/>  int a, b, c;                  struct Foo {<br/>};                                int a, b, c;<br/>namespace Ns {                  };<br/>class Bar {<br/>public:                         namespace Ns {<br/>  struct Foobar {               class Bar {<br/>    int a;                      public:<br/>    int b;                        struct Foobar {<br/>  };                                int a;<br/>private:                            int b;<br/>  int t;                          };<br/>  int method1() {<br/>    // ...                      private:<br/>  }                               int t;<br/>  enum List {<br/>    ITEM1,                        int method1() {<br/>    ITEM2                           // ...<br/>  };                              }<br/>  template<typename T><br/>  int method2(T x) {              enum List {<br/>    // ...                          ITEM1,<br/>  }                                 ITEM2<br/>  int i, j, k;                    };<br/>  int method3(int par) {<br/>    // ...                        template<typename T><br/>  }                               int method2(T x) {<br/>};                                  // ...<br/>class C {};                       }<br/>}<br/>                                  int i, j, k;<br/><br/>                                  int method3(int par) {<br/>                                    // ...<br/>                                  }<br/>                                };<br/><br/>                                class C {};<br/>                                }</pre></html>"
+EditorType=multiple
+Enabled=false
+Choices="SeparateDefinitionBlocks: Leave|SeparateDefinitionBlocks: Always|SeparateDefinitionBlocks: Never"
+ChoicesReadable="(Leave) Leave definition blocks as they are.|(Always) Insert an empty line between definition blocks.|(Never) Remove any empty line between definition blocks."
+ValueDefault=0
 
 [ShortNamespaceLines]
 Category=7
@@ -1132,9 +1187,73 @@ Category=5
 Description="<html>(SpaceBeforeParens) Defines in which cases to put a space before opening parentheses.</html>"
 EditorType=multiple
 Enabled=false
-Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: ControlStatementsExceptForEachMacros|SpaceBeforeParens: NonEmptyParentheses|SpaceBeforeParens: Always"
-ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(ControlStatementsExceptForEachMacros) Same as ControlStatements except this option doesn’t apply to ForEach macros. This is useful in projects where ForEach macros are treated as function calls instead of control statements.|(NonEmptyParentheses) Put a space before opening parentheses only if the parentheses are not empty i.e. '()'|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)"
+Choices="SpaceBeforeParens: Never|SpaceBeforeParens: ControlStatements|SpaceBeforeParens: ControlStatementsExceptForEachMacros|SpaceBeforeParens: NonEmptyParentheses|SpaceBeforeParens: Always|SpaceBeforeParens: Custom"
+ChoicesReadable="(Never) Never put a space before opening parentheses.|(ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).|(ControlStatementsExceptForEachMacros) Same as ControlStatements except this option doesn’t apply to ForEach macros. This is useful in projects where ForEach macros are treated as function calls instead of control statements.|(NonEmptyParentheses) Put a space before opening parentheses only if the parentheses are not empty i.e. '()'|(Always) Always put a space before opening parentheses, except when it’s prohibited by the syntax rules (in function-like macro definitions) or when determined by other style rules (after unary operators, opening parentheses, etc.)|(Custom) Configure each individual space before parentheses in SpaceBeforeParensOptions."
 ValueDefault=1
+
+[SpaceBeforeParensOptions]
+Category=5
+Description="<html>Control of individual space before parentheses.<p>If <code>SpaceBeforeParens</code> is set to <code>Custom</code>, use this to specify how each individual space before parentheses case should be handled. Otherwise, this is ignored.</html>"
+EditorType=boolean
+TrueFalse="SpaceBeforeParensOptions:|SpaceBeforeParensOptions:"
+Value=1
+ValueDefault=1
+
+[ - AfterControlStatements]
+Category=5
+Description="<html>If <code>true</code>, put space betwee control statement keywords (for/if/while...) and opening parentheses.<pre>true:                                  false:<br/>if (...) {}                     vs.    if(...) {}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterControlStatements: true|    AfterControlStatements: false"
+Value=0
+ValueDefault=0
+
+[ - AfterForeachMacros]
+Category=5
+Description="<html>If <code>true</code>, put space between foreach macros and opening parentheses.<pre>true:                                  false:<br/>FOREACH (...)                   vs.    FOREACH(...)<br/>  &lt;loop-body&gt;                            &lt;loop-body&gt;</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterForeachMacros: true|    AfterForeachMacros: false"
+Value=0
+ValueDefault=0
+
+[ - AfterFunctionDeclarationName]
+Category=5
+Description="<html>If <code>true</code>, put a space between function declaration name and opening parentheses.<pre>true:                                  false:<br/>void f ();                      vs.    void f();</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterFunctionDeclarationName: true|    AfterFunctionDeclarationName: false"
+Value=0
+ValueDefault=0
+
+[ - AfterFunctionDefinitionName]
+Category=5
+Description="<html>If <code>true</code>, put a space between function definition name and opening parentheses.<pre>true:                                  false:<br/>void f () {}                    vs.    void f() {}</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterFunctionDefinitionName: true|    AfterFunctionDefinitionName: false"
+Value=0
+ValueDefault=0
+
+[ - AfterIfMacros]
+Category=5
+Description="<html>If <code>true</code>, put space between if macros and opening parentheses.<pre>true:                                  false:<br/>IF (...)                        vs.    IF(...)<br/>  &lt;conditional-body&gt;                     &lt;conditional-body&gt;</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterIfMacros: true|    AfterIfMacros: false"
+Value=0
+ValueDefault=0
+
+[ - AfterOverloadedOperator]
+Category=5
+Description="<html>If <code>true</code>, put a space between operator overloading and opening parentheses.<pre>true:                                  false:<br/>void operator++ (int a);        vs.    void operator++(int a);<br/>object.operator++ (10);                object.operator++(10);</pre></html>"
+EditorType=boolean
+TrueFalse="    AfterOverloadedOperator: true|    AfterOverloadedOperator: false"
+Value=0
+ValueDefault=0
+
+[ - BeforeNonEmptyParentheses]
+Category=5
+Description="<html>If <code>true</code>, put a space before opening parentheses only if the parentheses are not empty.<pre>true:                                  false:<br/>void f (int a);                 vs.    void f();<br/>f (a);                                 f();</pre></html>"
+EditorType=boolean
+TrueFalse="    BeforeNonEmptyParentheses: true|    BeforeNonEmptyParentheses: false"
+Value=0
+ValueDefault=0
 
 [SpaceBeforeRangeBasedForLoopColon]
 Category=5
@@ -1214,7 +1333,7 @@ ValueDefault=0
 
 [SpacesInLineCommentPrefix]
 Category=5
-Description="<html>How many spaces are allowed at the start of a line comment. To disable the maximum set it to <code>-1</code>, apart from that the maximum takes precedence over the minimum.<pre>Minimum = 1 Maximum = -1<br/>// One space is forced<br/>//  but more spaces are possible<br/><br/>Minimum = 0<br/>Maximum = 0<br/>//Forces to start every comment directly after the slashes</pre>Note that in line comment sections the relative indent of the subsequent lines is kept, that means the following:<pre>before:                                   after:<br/>  Minimum: 1<br/>  //if (b) {                                // if (b) {<br/>  //  return true;                          //   return true;<br/>  //}                                       // }<br/><br/>  Maximum: 0<br/>  /// List:                                 ///List:<br/>  ///  - Foo                                /// - Foo<br/>  ///    - Bar                              ///   - Bar</pre></html>"
+Description="<html>How many spaces are allowed at the start of a line comment. To disable the maximum set it to <code>-1</code>, apart from that the maximum takes precedence over the minimum.<pre>Minimum = 1<br/>Maximum = -1<br/>// One space is forced<br/>//  but more spaces are possible<br/><br/>Minimum = 0<br/>Maximum = 0<br/>//Forces to start every comment directly after the slashes</pre>Note that in line comment sections the relative indent of the subsequent lines is kept, that means the following:<pre>before:                                   after:<br/>  Minimum: 1<br/>  //if (b) {                                // if (b) {<br/>  //  return true;                          //   return true;<br/>  //}                                       // }<br/><br/>  Maximum: 0<br/>  /// List:                                 ///List:<br/>  ///  - Foo                                /// - Foo<br/>  ///    - Bar                              ///   - Bar</pre></html>"
 EditorType=boolean
 TrueFalse="SpacesInLineCommentPrefix:|SpacesInLineCommentPrefix:"
 Value=1

--- a/indenters/uigui_clangformat.ini
+++ b/indenters/uigui_clangformat.ini
@@ -7,14 +7,14 @@ indenterFileName=clang-format
 indenterName=ClangFormat (C, C++, Java, JavaScript, JSON, ObjC, ObjC++, ProtoBuf, C#, Verilog)
 inputFileName=indentinput
 inputFileParameter="-style=file -i "
-manual=https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+manual=https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 outputFileName=indentinput
 outputFileParameter=none
 parameterOrder=pio
 stringparaminquotes=false
 showHelpParameter=-help
 useCfgFileParameter=none
-version=15.0.0
+version=16.0.0
 
 [Language]
 Category=0
@@ -158,11 +158,31 @@ ValueDefault=1
 
 [AlignTrailingComments]
 Category=4
-Description="<html>Aligns trailing comments.<pre>true:                                   false:<br/>int a;     // My comment a      vs.     int a; // My comment a<br/>int b = 2; // comment  b                int b = 2; // comment about b</pre></html>"
+Description="<html>Control of trailing comments.<p>NOTE: As of clang-format 16 this option is not a bool but can be set to the options. Conventional bool options still can be parsed as before.</p><pre># Example of usage:<br/>AlignTrailingComments:<br/>  Kind: Always<br/>  OverEmptyLines: 2</pre></html>"
 EditorType=boolean
-TrueFalse="AlignTrailingComments: true|AlignTrailingComments: false"
+TrueFalse="AlignTrailingComments:|AlignTrailingComments:"
 Value=1
 ValueDefault=1
+
+[ - Kind]
+Category=4
+Description="<html>( - Kind) Specifies the way to align trailing comments.</html>"
+EditorType=multiple
+Enabled=true
+Choices="    Kind: Leave|    Kind: Always|    Kind: Never"
+ChoicesReadable="(Leave) Leave trailing comments as they are.|(Always) Align trailing comments.|(Never) Don't align trailing comments but other formatter applies."
+ValueDefault=2
+
+[ - OverEmptyLines]
+Category=4
+Description="<html>How many empty lines to apply alignment.<p>When both <code>MaxEmptyLinesToKeep</code> and <code>OverEmptyLines</code> are set to 2, it formats like below.<pre>int a;      // all these<br/><br/>int ab;     // comments are<br/><br/><br/>int abcdef; // aligned</pre>When <code>MaxEmptyLinesToKeep</code> is set to 2 and <code>OverEmptyLines</code> is set to 1, it formats like below.<pre>int a;  // these are<br/><br/>int ab; // aligned<br/><br/><br/>int abcdef; // but this isn't</pre></p></html>"
+EditorType=numeric
+Enabled=true
+CallName="    OverEmptyLines: "
+MaxVal=65535
+MinVal=0
+Value=0
+ValueDefault=0
 
 [AllowAllArgumentsOnNextLine]
 Category=1
@@ -237,7 +257,7 @@ Description="<html>(AllowShortLambdasOnASingleLine) Dependent on the value, <cod
 EditorType=multiple
 Enabled=false
 Choices="AllowShortLambdasOnASingleLine: None|AllowShortLambdasOnASingleLine: Empty|AllowShortLambdasOnASingleLine: Inline|AllowShortLambdasOnASingleLine: All"
-ChoicesReadable="(None) Never merge lambdas into a single line.|(Empty) Only merge empty lambdas.|(Inline) Merge lambda into a single line if argument of a function.|(All) Merge all lambdas fitting on a single line."
+ChoicesReadable="(None) Never merge lambdas into a single line.|(Empty) Only merge empty lambdas.|(Inline) Merge lambda into a single line if the lambda is argument of a function.|(All) Merge all lambdas fitting on a single line."
 ValueDefault=3
 
 [AllowShortLoopsOnASingleLine]
@@ -335,7 +355,7 @@ ValueDefault=0
 
 [ - AfterClass]
 Category=2
-Description="<html>Wrap <code>class</code> definitions.<pre>true:<br/>class foo {};<br/><br/>false:<br/>class foo<br/>{};</pre></html>"
+Description="<html>Wrap <code>class</code> definitions.<pre>true:<br/>class foo<br/>{};<br/><br/>false:<br/>class foo {};</pre></html>"
 EditorType=boolean
 TrueFalse="    AfterClass: true|    AfterClass: false"
 Value=0
@@ -470,6 +490,15 @@ TrueFalse="    SplitEmptyNamespace: true|    SplitEmptyNamespace: false"
 Value=1
 ValueDefault=1
 
+[BreakAfterAttributes]
+Category=1
+Description="<html>(BreakAfterAttributes) Break after a group of C++11 attributes before a function declaration/definition name.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakAfterAttributes: Always|BreakAfterAttributes: Leave|BreakAfterAttributes: Never"
+ChoicesReadable="(Always) Always break after attributes.|(Leave) Leave the line breaking after attributes as is.|(Never) Never break after attributes."
+ValueDefault=2
+
 [BreakAfterJavaFieldAnnotations]
 Category=1
 Description="<html>Break after each annotation on a field in Java files.<pre>true:                                  false:<br/>@Partial                       vs.     @Partial @Mock DataLoad loader;<br/>@Mock<br/>DataLoad loader;</pre></html>"
@@ -477,6 +506,14 @@ EditorType=boolean
 TrueFalse="BreakAfterJavaFieldAnnotations: true|BreakAfterJavaFieldAnnotations: false"
 Value=0
 ValueDefault=0
+
+[BreakArrays]
+Category=1
+Description="<html>If <code>true</code>, clang-format will always break after a Json array <code>[</code> otherwise it will scan until the closing <code>]</code> to determine if it should add newlines between elements (prettier compatible).<br/><br/>NOTE: This is currently only for formatting JSON.<pre>true:                                  false:<br/>[                          vs.      [1, 2, 3, 4]<br/>  1,<br/>  2,<br/>  3,<br/>  4<br/>]</pre></html>"
+EditorType=boolean
+TrueFalse="BreakArrays: true|BreakArrays: false"
+Value=1
+ValueDefault=1
 
 [BreakBeforeBinaryOperators]
 Category=1
@@ -504,6 +541,15 @@ Enabled=false
 Choices="BreakBeforeConceptDeclarations: Never|BreakBeforeConceptDeclarations: Allowed|BreakBeforeConceptDeclarations: Always"
 ChoicesReadable="(Never) Keep the template declaration line together with `concept`.|(Allowed) Breaking between template declaration and `concept` is allowed. The actual behavior depends on the content and line breaking rules and penalities.|(Always) Always break before `concept`, putting it in the line after the template declaration."
 ValueDefault=2
+
+[BreakBeforeInlineASMColon]
+Category=1
+Description="<html>(BreakBeforeInlineASMColon) The inline ASM colon style to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="BreakBeforeInlineASMColon: Never|BreakBeforeInlineASMColon: OnlyMultiline|BreakBeforeInlineASMColon: Always"
+ChoicesReadable="(Never) No break before inline ASM colon.|(OnlyMultiline) Break before inline ASM colon if the line length is longer than column limit.|(Always) Always break before inline ASM colon."
+ValueDefault=1
 
 [BreakBeforeTernaryOperators]
 Category=1
@@ -605,14 +651,6 @@ TrueFalse="Cpp11BracedListStyle: true|Cpp11BracedListStyle: false"
 Value=1
 ValueDefault=1
 
-[DeriveLineEnding]
-Category=7
-Description="<html>Analyze the formatted file for the most used line ending (<code>\r\n</code> or <code>\n</code>). <code>UseCRLF<code> is only used as a fallback if none can be derived.</html>"
-EditorType=boolean
-TrueFalse="DeriveLineEnding: true|DeriveLineEnding: false"
-Value=0
-ValueDefault=0
-
 [DerivePointerAlignment]
 Category=5
 Description="<html>If <code>true</code>, analyze the formatted file for the most common alignment of <code>&</code> and <code>*</code>. Pointer and reference alignment styles are going to be updated according to the preferences found in the file. <code>PointerAlignment</code> is then used only as fallback.</html>"
@@ -649,7 +687,7 @@ ValueDefault=2
 
 [FixNamespaceComments]
 Category=7
-Description="<html>If <code>true</code>, clang-format adds missing namespace end comments for short namespaces and fixes invalid existing ones. Short ones are controlled by "ShortNamespaceLines".<pre>true:                                  false:<br/>namespace a {                  vs.     namespace a {<br/>foo();                                 foo();<br/>bar();                                 bar();<br/>} // namespace a                       }</pre></html>"
+Description="<html>If <code>true</code>, clang-format adds missing namespace end comments for namespaces and fixes invalid existing ones. This doesn't affect short namespaces, which are controlled by <code>ShortNamespaceLines</code>.<pre>true:                                  false:<br/>namespace longNamespace {      vs.     namespace longNamespace {<br/>void foo();                            void foo();<br/>void bar();                            void bar();<br/>} // namespace a                       }<br/>namespace shortNamespace {             namespace shortNamespace {<br/>void baz();                            void baz();<br/>}                                      }</pre></html>"
 EditorType=boolean
 TrueFalse="FixNamespaceComments: true|FixNamespaceComments: false"
 Value=1
@@ -785,6 +823,14 @@ TrueFalse="InsertBraces: true|InsertBraces: false"
 Value=0
 ValueDefault=0
 
+[InsertNewlineAtEOF]
+Category=7
+Description="<html>Insert a newline at end of file if missing.</html>"
+EditorType=boolean
+TrueFalse="InsertNewlineAtEOF: true|InsertNewlineAtEOF: false"
+Value=0
+ValueDefault=0
+
 [InsertTrailingCommas]
 Category=7
 Description="<html>(InsertTrailingCommas) If set to <code>Wrapped</code> will insert trailing commas in container literals (arrays and objects) that wrap across multiple lines. It is currently only available for JavaScript and disabled by default. Cannot be used together with <code>BinPackArguments</code> as inserting the comma disables bin-packing.<pre>Wrapped:<br/>const someArray = [<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>aaaaaaaaaaaaaaaaaaaaaaaaaa,<br/>//                        ^ inserted<br/>]</pre></html>"
@@ -792,6 +838,47 @@ EditorType=multiple
 Enabled=false
 Choices="InsertTrailingCommas: None|InsertTrailingCommas: Wrapped"
 ChoicesReadable="(None) Do not insert trailing commas.|(Wrapped) Insert trailing commas in container literals that were wrapped over multiple lines."
+ValueDefault=0
+
+[IntegerLiteralSeparator]
+Category=7
+Description="<html>Format integer literal separators (<code>'</code> for C++ and <code>_</code> for C#, Java, and JavaScript).<p>Nested configuration flags:</p><p>Separator format of integer literals of different bases.</p><p>If negative, remove separators. If <code>0</code>, leave the literal as is. If positive, insert separators between digits starting from the rightmost digit.</p><p>For example, the config below will leave separators in binary literals alone, insert separators in decimal literals to separate the digits into groups of 3, and remove separators in hexadecimal literals.</p><pre>IntegerLiteralSeparator:<br/>  Binary: 0<br/>  Decimal: 3<br/>  Hex: -1</pre></html>"
+EditorType=boolean
+TrueFalse="IntegerLiteralSeparator:|IntegerLiteralSeparator:"
+Value=1
+ValueDefault=1
+
+[ - Binary]
+Category=7
+Description="<html>Format separators in binary literals.</html>"
+EditorType=numeric
+Enabled=false
+CallName="    Binary: "
+MaxVal=255
+MinVal=-256
+Value=0
+ValueDefault=0
+
+[ - Decimal]
+Category=7
+Description="<html>Format separators in decimal literals.</html>"
+EditorType=numeric
+Enabled=false
+CallName="    Decimal: "
+MaxVal=255
+MinVal=-256
+Value=0
+ValueDefault=0
+
+[ - Hex]
+Category=7
+Description="<html>Format separators in hexadecimal literals.</html>"
+EditorType=numeric
+Enabled=false
+CallName="    Hex: "
+MaxVal=255
+MinVal=-256
+Value=0
 ValueDefault=0
 
 [JavaImportGroups]
@@ -836,6 +923,15 @@ Enabled=false
 Choices="LambdaBodyIndentation: Signature|LambdaBodyIndentation: OuterScope"
 ChoicesReadable="(Signature) Align lambda body relative to the lambda signature. This is the default.|(OuterScope) Align lambda body relative to the indentation level of the outer scope the lambda signature resides in."
 ValueDefault=0
+
+[LineEnding]
+Category=7
+Description="<html>(LineEnding) Line ending style (<code>\n</code> or <code>\r\n</code>) to use.</html>"
+EditorType=multiple
+Enabled=false
+Choices="LineEnding: LF|LineEnding: CRLF|LineEnding: DeriveLF|LineEnding: DeriveCRLF"
+ChoicesReadable="(LF) Use \n.|(CRLF) Use \r\n.|(DeriveLF) Use \n unless the input has more lines ending in \r\n.|(DeriveCRLF) Use \r\n unless the input has more lines ending in \n."
+ValueDefault=2
 
 [MacroBlockBegin]
 Category=3
@@ -1078,7 +1174,7 @@ ValueDefault=0
 
 [QualifierOrder]
 Category=7
-Description="<html>The order in which the qualifiers appear.<p>Order is an array that can contain any of the following:<ul><li>const</li><li>inline</li><li>static</li><li>constexpr</li><li>volatile</li><li>restrict</li><li>type</li></ul>Note: it MUST contain 'type'.<br/>Items to the left of 'type' will be placed to the left of the type and aligned in the order supplied. Items to the right of 'type' will be placed to the right of the type and aligned in the order supplied.</html>"
+Description="<html>The order in which the qualifiers appear.<p>Order is an array that can contain any of the following:<ul><li>const</li><li>inline</li><li>static</li><li>friend</li><li>constexpr</li><li>volatile</li><li>restrict</li><li>type</li></ul>Note: it MUST contain 'type'.<br/>Items to the left of 'type' will be placed to the left of the type and aligned in the order supplied. Items to the right of 'type' will be placed to the right of the type and aligned in the order supplied.</html>"
 EditorType=string
 CallName="QualifierOrder: "
 Enabled=false
@@ -1096,7 +1192,7 @@ ValueDefault=0
 
 [ReflowComments]
 Category=1
-Description="<html>If <code>true</code>, clang-format will attempt to re-flow comments.<pre>false:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information */<br/><br/>true:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/>// information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/> * information */</pre></html>"
+Description="<html>If <code>true</code>, clang-format will attempt to re-flow comments. That is it will touch a comment and *reflow* long comments into new lines, trying to obey the <code>ColumnLimit</code>.<pre>false:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of information */<br/><br/>true:<br/>// veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/>// information<br/>/* second veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongComment with plenty of<br/> * information */</pre></html>"
 EditorType=boolean
 TrueFalse="ReflowComments: true|ReflowComments: false"
 Value=1
@@ -1110,6 +1206,14 @@ TrueFalse="RemoveBracesLLVM: true|RemoveBracesLLVM: false"
 Value=0
 ValueDefault=0
 
+[RemoveSemicolon]
+Category=7
+Description="<html>Remove semicolons after the closing brace of a non-empty function.<p><b>Warning</b></p>Setting this option to <code>true</code> could lead to incorrect code formatting due to clang-format's lack of complete semantic information. As such, extra care should be taken to review code changes made by this option.<pre>false:                                     true:<br/><br/>int max(int a, int b) {                    int max(int a, int b) {<br/>  return a > b ? a : b;                      return a > b ? a : b;<br/>};                                         }</pre></html>"
+EditorType=boolean
+TrueFalse="RemoveSemicolon: true|RemoveSemicolon: false"
+Value=0
+ValueDefault=0
+
 [RequiresClausePosition]
 Category=1
 Description="<html>(RequiresClausePosition) </html>"
@@ -1117,6 +1221,15 @@ EditorType=multiple
 Enabled=false
 Choices="RequiresClausePosition: OwnLine|RequiresClausePosition: WithPreceding|RequiresClausePosition: WithFollowing|RequiresClausePosition: SingleLine"
 ChoicesReadable="(OwnLine) Always put the `requires` clause on its own line.|(WithPreceding) Try to put the clause together with the preceding part of a declaration. For class templates: stick to the template declaration. For function templates: stick to the template declaration. For function declaration followed by a requires clause: stick to the parameter list.|(WithFollowing) Try to put the `requires` clause together with the class or function declaration.|(SingleLine) Try to put everything in the same line if possible. Otherwise normal line breaking rules take over."
+ValueDefault=0
+
+[RequiresExpressionIndentation]
+Category=3
+Description="<html>(RequiresExpressionIndentation) The indentation used for requires expression bodies.</html>"
+EditorType=multiple
+Enabled=false
+Choices="RequiresExpressionIndentation: OuterScope|RequiresExpressionIndentation: Keyword"
+ChoicesReadable="(OuterScope) Align requires expression body relative to the indentation level of the outer scope the requires expression resides in. This is the default.|(Keyword) Align requires expression body relative to the requires keyword."
 ValueDefault=0
 
 [SeparateDefinitionBlocks]
@@ -1160,11 +1273,12 @@ ValueDefault=0
 
 [SortUsingDeclarations]
 Category=7
-Descriptions="<html>If <code>true</code>, clang-format will sort <code>using</code> declarations.<p>The order of <code>using</code> declarations is defined as follows: Split the strings by “::” and discard any initial empty strings. The last element of each list is a non-namespace name; all others are namespace names. Sort the lists of names lexicographically, where the sort order of individual names is that all non-namespace names come before all namespace names, and within those groups, names are in case-insensitive lexicographic order.<pre>false:                                 true:<br/>using std::cout;               vs.     using std::cin;<br/>using std::cin;                        using std::cout;</pre></html>"
-EditorType=boolean
-TrueFalse="SortUsingDeclarations: true|SortUsingDeclarations: false"
-Value=1
-ValueDefault=1
+Descriptions="<html>(SortUsingDeclarations) Controls if and how clang-format will sort using declarations.</html>"
+EditorType=multiple
+Enabled=false
+Choices="SortUsingDeclarations: Never|SortUsingDeclarations: Lexicographic|SortUsingDeclarations: LexicographicNumeric"
+ChoicesReadable="(Never) Using declarations are never sorted.|(Lexicographic) Using declarations are sorted in the order defined as follows: Split the strings by '::' and discard any initial empty strings. Sort the lists of names lexicographically, and within those groups, names are in case-insensitive lexicographic order.|(LexicographicNumeric) Using declarations are sorted in the order defined as follows: Split the strings by '::' and discard any initial empty strings. The last element of each list is a non-namespace name; all others are namespace names. Sort the lists of names lexicographically, where the sort order of individual names is that all non-namespace names come before all namespace names, and within those groups, names are in case-insensitive lexicographic order."
+ValueDefault=2
 
 [SpaceAfterCStyleCast]
 Category=5
@@ -1406,7 +1520,7 @@ ValueDefault=0
 
 [SpacesInLineCommentPrefix]
 Category=5
-Description="<html>How many spaces are allowed at the start of a line comment. To disable the maximum set it to <code>-1</code>, apart from that the maximum takes precedence over the minimum.<pre>Minimum = 1<br/>Maximum = -1<br/>// One space is forced<br/>//  but more spaces are possible<br/><br/>Minimum = 0<br/>Maximum = 0<br/>//Forces to start every comment directly after the slashes</pre>Note that in line comment sections the relative indent of the subsequent lines is kept, that means the following:<pre>before:                                   after:<br/>  Minimum: 1<br/>  //if (b) {                                // if (b) {<br/>  //  return true;                          //   return true;<br/>  //}                                       // }<br/><br/>  Maximum: 0<br/>  /// List:                                 ///List:<br/>  ///  - Foo                                /// - Foo<br/>  ///    - Bar                              ///   - Bar</pre></html>"
+Description="<html>How many spaces are allowed at the start of a line comment. To disable the maximum set it to <code>-1</code>, apart from that the maximum takes precedence over the minimum.<pre>Minimum = 1<br/>Maximum = -1<br/>// One space is forced<br/>//  but more spaces are possible<br/><br/>Minimum = 0<br/>Maximum = 0<br/>//Forces to start every comment directly after the slashes</pre>Note that in line comment sections the relative indent of the subsequent lines is kept, that means the following:<pre>before:                                   after:<br/>  Minimum: 1<br/>  //if (b) {                                // if (b) {<br/>  //  return true;                          //   return true;<br/>  //}                                       // }<br/><br/>  Maximum: 0<br/>  /// List:                                 ///List:<br/>  ///  - Foo                                /// - Foo<br/>  ///    - Bar                              ///   - Bar</pre>This option has only effect if <code>ReflowComments</code> is set to <code>true</code>.</html>"
 EditorType=boolean
 TrueFalse="SpacesInLineCommentPrefix:|SpacesInLineCommentPrefix:"
 Value=1
@@ -1496,14 +1610,6 @@ CallName="TypenameMacros: "
 Enabled=false
 Value="[]"
 ValueDefault="[]"
-
-[UseCRLF]
-Category=7
-Description="<html>Use <code>\r\n</code> instead of <code>\n</code> for line breaks. Also used as fallback if <code>DeriveLineEnding</code> is true.</html>"
-EditorType=boolean
-TrueFalse="UseCRLF: true|UseCRLF: false"
-Value=0
-ValueDefault=0
 
 [UseTab]
 Category=3

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/17.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,6 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
+                <li><a class="external" href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>
@@ -187,7 +188,7 @@ a.external
             </ol>
         </ol>
         <b>Indenter binary packages</b> can be downloaded from the project at SourceForge
-        <a class="external" href="http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094">here</a>.
+        <a class="external" href="http://sourceforge.net/project/showfiles.php?group_id=167482&package_id=293094">here</a>. <b>ClangFormat</b> is not part of them (yet), and you can download it separately at <a class="external" href="http://llvm.org/builds/">the LLVM Builds page</a>. (Rename it to <code>clang-format.exe</code> after downloading if needed.)
         <p>Beneath the possibility to build UiGUI using qmake, also project files for Visual Studio 2005
         and XCode are included.</p>
     </p>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://releases.llvm.org/15.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>

--- a/readme.html
+++ b/readme.html
@@ -63,7 +63,7 @@ a.external
             <ul>
                 <li><a class="external" href="http://astyle.sourceforge.net/">Artistic Styler</a></li>
                 <li><a class="external" href="http://invisible-island.net/bcpp/">BCPP</a></li>
-                <li><a class="external" href="https://clang.llvm.org/docs/ClangFormat.html">ClangFormat</a></li>
+                <li><a class="external" href="https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html">ClangFormat</a></li>
                 <li><a class="external" href="http://www.siber.com/sct/tools/cbl-beau.html">Cobol Beautify</a></li>
                 <li><a class="external" href="http://csstidy.sourceforge.net/">CSSTidy</a></li>
                 <li><a class="external" href="ftp://ftp.ifremer.fr/ifremer/ditigo/fortran90/">Fortran 90 PPR</a></li>


### PR DESCRIPTION
Add an indenter configuration file for [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) v17.0.0. It can generate all the [documented `.clang-format` options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html), except the following:

 - `ExperimentalAutoDetectBinPacking`, because it is discouraged from use in config files.

 - `AlwaysBreakAfterDefinitionReturnType`, `DeriveLineEnding`, `SpaceInEmptyParentheses`, `SpacesInCStyleCastParentheses`, `SpacesInConditionalStatement`, `SpacesInParentheses` and `UseCRLF`, because they are now deprecated.

 - `IncludeCategories` and `RawStringFormats`, because their option values are highly structured YAML and beyond the capabilities of UniversalIndentGUI.

Also enlist ClangFormat in the list of supported indenters in the text, HTML and Markdown README files (but not in the binary PDF file) and in the release packaging scripts.